### PR TITLE
Feat/payment refund, updateStatus

### DIFF
--- a/common/src/main/java/com/bobjool/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/bobjool/common/exception/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
     UNSUPPORTED_PG_NAME(HttpStatus.BAD_REQUEST, "지원하지 않는 PG사 이름입니다."),
     INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "결제 금액은 양수여야 합니다."),
     PAYMENT_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "알 수 없는 이유로 결제에 실패했습니다."),
-
+    CANNOT_REFUND(HttpStatus.CONFLICT, "환불할 수 없는 상태입니다."),
 
     // 알림
 

--- a/reservation/http/payment.http
+++ b/reservation/http/payment.http
@@ -3,11 +3,11 @@ POST localhost:19005/api/v1/payments
 Content-Type: application/json
 
 {
-  "reservationId": "8b2fcc3a-2a7d-4a32-b679-d9bb39378b4d",
-  "userId": 12345,
+  "reservation_id": "8b2fcc3a-2a7d-4a32-b679-d9bb39378b4d",
+  "user_id": 12345,
   "amount": 10000,
   "method": "CARD",
-  "pgName": "TOSS"
+  "pg_name": "TOSS"
 }
 
 ### 결제 검색
@@ -21,3 +21,7 @@ Content-Type: application/json
 {
   "status": "REFUND"
 }
+
+### 환불 요청
+POST localhost:19005/api/v1/payments/refund/393fcd8f-9895-4f4f-9ea8-46ba6e9cd2e2
+Content-Type: application/json

--- a/reservation/http/payment.http
+++ b/reservation/http/payment.http
@@ -12,4 +12,12 @@ Content-Type: application/json
 
 ### 결제 검색
 GET localhost:19005/api/v1/payments?page=0&size=5&sort=createdAt,DESC
-Content-Type:
+Content-Type: application/json
+
+### 결제 상태 변경
+PATCH localhost:19005/api/v1/payments/status/9f24d789-6e40-42fc-af7a-f2c03cfd5bff
+Content-Type: application/json
+
+{
+  "status": "REFUND"
+}

--- a/reservation/src/main/java/com/bobjool/reservation/application/dto/PaymentUpdateDto.java
+++ b/reservation/src/main/java/com/bobjool/reservation/application/dto/PaymentUpdateDto.java
@@ -1,0 +1,6 @@
+package com.bobjool.reservation.application.dto;
+
+public record PaymentUpdateDto(
+        String status
+) {
+}

--- a/reservation/src/main/java/com/bobjool/reservation/application/service/PaymentService.java
+++ b/reservation/src/main/java/com/bobjool/reservation/application/service/PaymentService.java
@@ -79,4 +79,15 @@ public class PaymentService {
         payment.updateStatus(PaymentStatus.of(paymentUpdateDto.status()));
         return PaymentResponse.from(payment);
     }
+
+    @Transactional
+    public PaymentResponse refundPayment(UUID paymentId) {
+        log.info("refundPayment.PaymentId = {}", paymentId);
+
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND));
+
+        payment.updateStatus(PaymentStatus.REFUND);
+        return PaymentResponse.from(payment);
+    }
 }

--- a/reservation/src/main/java/com/bobjool/reservation/application/service/PaymentService.java
+++ b/reservation/src/main/java/com/bobjool/reservation/application/service/PaymentService.java
@@ -5,6 +5,7 @@ import com.bobjool.common.exception.ErrorCode;
 import com.bobjool.reservation.application.dto.PaymentCreateDto;
 import com.bobjool.reservation.application.dto.PaymentResponse;
 import com.bobjool.reservation.application.dto.PaymentSearchDto;
+import com.bobjool.reservation.application.dto.PaymentUpdateDto;
 import com.bobjool.reservation.application.interfaces.PgClient;
 import com.bobjool.reservation.domain.entity.Payment;
 import com.bobjool.reservation.domain.enums.PaymentMethod;
@@ -17,6 +18,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -64,5 +67,16 @@ public class PaymentService {
                 paymentSearchDto.endDate(),
                 pageable);
         return paymentPage.map(PaymentResponse::from);
+    }
+
+    @Transactional
+    public PaymentResponse updatePaymentStatus(PaymentUpdateDto paymentUpdateDto, UUID paymentId) {
+        log.info("updatePayment.PaymentUpdateDto = {}", paymentUpdateDto);
+
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND));
+
+        payment.updateStatus(PaymentStatus.of(paymentUpdateDto.status()));
+        return PaymentResponse.from(payment);
     }
 }

--- a/reservation/src/main/java/com/bobjool/reservation/domain/entity/Payment.java
+++ b/reservation/src/main/java/com/bobjool/reservation/domain/entity/Payment.java
@@ -75,6 +75,23 @@ public class Payment extends BaseEntity {
     }
 
     public void updateStatus(PaymentStatus status) {
+        if (status == PaymentStatus.REFUND) {
+            if (isNotRefundable()) {
+                throw new BobJoolException(ErrorCode.CANNOT_REFUND);
+            }
+        }
         this.status = status;
+    }
+
+    /**
+     * 도메인 규칙 - COMPLETE 상태만 REFUND 로 변경이 가능하다.
+     * 현재 상태(status) 검증 메서드
+     * */
+    private boolean isRefundable() {
+        return status == PaymentStatus.COMPLETE;
+    }
+
+    private boolean isNotRefundable() {
+        return !isRefundable();
     }
 }

--- a/reservation/src/main/java/com/bobjool/reservation/domain/entity/Payment.java
+++ b/reservation/src/main/java/com/bobjool/reservation/domain/entity/Payment.java
@@ -73,4 +73,8 @@ public class Payment extends BaseEntity {
             throw new BobJoolException(ErrorCode.INVALID_PAYMENT_AMOUNT);
         }
     }
+
+    public void updateStatus(PaymentStatus status) {
+        this.status = status;
+    }
 }

--- a/reservation/src/main/java/com/bobjool/reservation/presentation/controller/PaymentController.java
+++ b/reservation/src/main/java/com/bobjool/reservation/presentation/controller/PaymentController.java
@@ -55,5 +55,12 @@ public class PaymentController {
         return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
     }
 
+    @PostMapping("/refund/{paymentId}")
+    public ResponseEntity<ApiResponse<PaymentResponse>> refundPayment(@PathVariable("paymentId") UUID paymentId) {
+        log.info("refundPayment.paymentId={}", paymentId);
+        PaymentResponse response = paymentService.refundPayment(paymentId);
+        return ApiResponse.success(SuccessCode.SUCCESS, response);
+    }
+
 
 }

--- a/reservation/src/main/java/com/bobjool/reservation/presentation/controller/PaymentController.java
+++ b/reservation/src/main/java/com/bobjool/reservation/presentation/controller/PaymentController.java
@@ -7,6 +7,7 @@ import com.bobjool.reservation.application.dto.PaymentResponse;
 import com.bobjool.reservation.application.dto.PaymentSearchDto;
 import com.bobjool.reservation.application.service.PaymentService;
 import com.bobjool.reservation.presentation.dto.PaymentCreateReqDto;
+import com.bobjool.reservation.presentation.dto.PaymentUpdateReqDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -45,5 +47,13 @@ public class PaymentController {
                 = paymentService.search(new PaymentSearchDto(userId, status, startDate, endDate), pageable);
         return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(responsePage));
     }
+
+    @PatchMapping("/status/{paymentId}")
+    public ResponseEntity<ApiResponse<PaymentResponse>> updatePaymentStatus(@Valid @RequestBody PaymentUpdateReqDto paymentUpdateReqDto,
+                                    @PathVariable("paymentId") UUID paymentId) {
+        PaymentResponse response = paymentService.updatePaymentStatus(paymentUpdateReqDto.toServiceDto(), paymentId);
+        return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
+    }
+
 
 }

--- a/reservation/src/main/java/com/bobjool/reservation/presentation/dto/PaymentUpdateReqDto.java
+++ b/reservation/src/main/java/com/bobjool/reservation/presentation/dto/PaymentUpdateReqDto.java
@@ -1,0 +1,12 @@
+package com.bobjool.reservation.presentation.dto;
+
+import com.bobjool.reservation.application.dto.PaymentUpdateDto;
+import jakarta.validation.constraints.NotBlank;
+
+public record PaymentUpdateReqDto(
+        @NotBlank(message = "변경할 결제 상태는 필수 입력값입니다.") String status
+) {
+    public PaymentUpdateDto toServiceDto() {
+        return new PaymentUpdateDto(status);
+    }
+}

--- a/reservation/src/main/resources/application-dev.yml
+++ b/reservation/src/main/resources/application-dev.yml
@@ -18,11 +18,14 @@ spring:
       use_sql_comments: true
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  jackson:
+    property-naming-strategy: SNAKE_CASE
 
 eureka:
   client:
     serviceUrl:
       defaultZone: http://localhost:19000/eureka/
+
 
 
 #management:

--- a/reservation/src/test/java/com/bobjool/reservation/domain/entity/PaymentTest.java
+++ b/reservation/src/test/java/com/bobjool/reservation/domain/entity/PaymentTest.java
@@ -71,4 +71,26 @@ class PaymentTest {
                 .hasMessage("결제 금액은 양수여야 합니다."); // validateAmount 메서드에서 정의한 메시지와 일치해야 함
     }
 
+    @DisplayName("updateStatus - 결제 상태를 변경한다.")
+    @Test
+    void updateStatus_success() {
+        // given - status 가 COMPLETE 인 Payment 가 있을 때
+        UUID reservationId = UUID.randomUUID();
+        Long userId = 12345L;
+        Integer amount = 1000;
+        PaymentStatus status = PaymentStatus.COMPLETE;
+        PaymentMethod method = PaymentMethod.CARD;
+        PgName toss = PgName.TOSS;
+
+        Payment payment = Payment.create(reservationId, userId, amount, status, method, toss);
+        PaymentStatus targetStatus = PaymentStatus.REFUND;
+
+        // when - updateStatus 를 호출 하면,
+        payment.updateStatus(targetStatus);
+
+        assertThat(payment.getStatus()).isEqualTo(targetStatus);
+        assertThat(payment.getUserId()).isEqualTo(userId);
+
+    }
+
 }

--- a/reservation/src/test/java/com/bobjool/reservation/domain/entity/PaymentTest.java
+++ b/reservation/src/test/java/com/bobjool/reservation/domain/entity/PaymentTest.java
@@ -78,6 +78,27 @@ class PaymentTest {
         UUID reservationId = UUID.randomUUID();
         Long userId = 12345L;
         Integer amount = 1000;
+        PaymentStatus status = PaymentStatus.PENDING;
+        PaymentMethod method = PaymentMethod.CARD;
+        PgName toss = PgName.TOSS;
+
+        Payment payment = Payment.create(reservationId, userId, amount, status, method, toss);
+        PaymentStatus targetStatus = PaymentStatus.FAIL;
+
+        // when - updateStatus 를 호출 하면,
+        payment.updateStatus(targetStatus);
+
+        assertThat(payment.getStatus()).isEqualTo(targetStatus);
+        assertThat(payment.getUserId()).isEqualTo(userId);
+    }
+
+    @DisplayName("updateStatus - COMPLETE 상태에서만 REFUND 로 변경 가능하다")
+    @Test
+    void updateStatus_whenCompleteToRefund() {
+        // given - status 가 COMPLETE 인 Payment 가 있을 때
+        UUID reservationId = UUID.randomUUID();
+        Long userId = 12345L;
+        Integer amount = 1000;
         PaymentStatus status = PaymentStatus.COMPLETE;
         PaymentMethod method = PaymentMethod.CARD;
         PgName toss = PgName.TOSS;
@@ -85,12 +106,31 @@ class PaymentTest {
         Payment payment = Payment.create(reservationId, userId, amount, status, method, toss);
         PaymentStatus targetStatus = PaymentStatus.REFUND;
 
-        // when - updateStatus 를 호출 하면,
+        // when - updateStatus 를 호출하면
         payment.updateStatus(targetStatus);
 
+        // then - 상태가 REFUND 로 변경된다
         assertThat(payment.getStatus()).isEqualTo(targetStatus);
-        assertThat(payment.getUserId()).isEqualTo(userId);
+    }
 
+    @DisplayName("updateStatus - PENDING, FAIL, REFUND 상태에서는 REFUND 로 변경 불가하다")
+    @ParameterizedTest
+    @ValueSource(strings = {"PENDING", "FAIL", "REFUND"})
+    void updateStatus_whenNotComplete(String initialStatus) {
+        // given - status 가 PENDING, FAIL, REFUND 인 Payment 가 있을 때
+        UUID reservationId = UUID.randomUUID();
+        Long userId = 12345L;
+        Integer amount = 1000;
+        PaymentMethod method = PaymentMethod.CARD;
+        PgName toss = PgName.TOSS;
+
+        Payment payment = Payment.create(reservationId, userId, amount, PaymentStatus.valueOf(initialStatus), method, toss);
+        PaymentStatus targetStatus = PaymentStatus.REFUND;
+
+        // when & then - updateStatus 호출 시 예외가 발생해야 한다
+        assertThatThrownBy(() -> payment.updateStatus(targetStatus))
+                .isInstanceOf(BobJoolException.class)
+                .hasMessage("환불할 수 없는 상태입니다.");
     }
 
 }

--- a/reservation/src/test/java/com/bobjool/reservation/presentation/controller/PaymentControllerTest.java
+++ b/reservation/src/test/java/com/bobjool/reservation/presentation/controller/PaymentControllerTest.java
@@ -247,4 +247,17 @@ class PaymentControllerTest {
                 .andExpect(jsonPath("$.message").value("변경할 결제 상태는 필수 입력값입니다."))
                 .andExpect(jsonPath("$.data").isEmpty());
     }
+
+    @DisplayName("updatePaymentStatus - 성공")
+    @Test
+    void refundPayment_success() throws Exception {
+        // given - 정상 요청일 때
+        UUID paymentId = UUID.randomUUID();
+
+        // when & then - 200 상태코드 반환하는지 본다
+        mockMvc.perform(post("/api/v1/payments/refund/{paymentId}", paymentId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
 }

--- a/reservation/src/test/java/com/bobjool/reservation/presentation/controller/PaymentControllerTest.java
+++ b/reservation/src/test/java/com/bobjool/reservation/presentation/controller/PaymentControllerTest.java
@@ -2,6 +2,7 @@ package com.bobjool.reservation.presentation.controller;
 
 import com.bobjool.reservation.application.service.PaymentService;
 import com.bobjool.reservation.presentation.dto.PaymentCreateReqDto;
+import com.bobjool.reservation.presentation.dto.PaymentUpdateReqDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.UUID;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -211,4 +213,38 @@ class PaymentControllerTest {
                 .andExpect(jsonPath("$.data").isEmpty());
     }
 
+    @DisplayName("updatePaymentStatus - 성공")
+    @Test
+    void updatePaymentStatus() throws Exception {
+        // given - 정상 요청일 때
+        String status = "REFUND";
+        PaymentUpdateReqDto paymentUpdateReqDto = new PaymentUpdateReqDto(status);
+        UUID paymentId = UUID.randomUUID();
+
+        // when & then - 200 상태코드 반환하는지 본다
+        mockMvc.perform(patch("/api/v1/payments/status/{paymentId}", paymentId)
+                        .content(objectMapper.writeValueAsString(paymentUpdateReqDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("updatePaymentStatus - status가 없는 경우 400 상태코드")
+    @Test
+    void updatePaymentStatus_whenNonStatus() throws Exception {
+        // given - 정상 요청일 때
+        String status = null;
+        PaymentUpdateReqDto paymentUpdateReqDto = new PaymentUpdateReqDto(status);
+        UUID paymentId = UUID.randomUUID();
+
+        // when & then - 200 상태코드 반환하는지 본다
+        mockMvc.perform(patch("/api/v1/payments/status/{paymentId}", paymentId)
+                        .content(objectMapper.writeValueAsString(paymentUpdateReqDto))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.message").value("변경할 결제 상태는 필수 입력값입니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/payment-refund #4 #6 -> dev
### 이슈
- #4 
- #6 
### Description
- 환불 요청만 하려고 했는데, 동일한 작업이 많아서 updateStatus도 함께 진행했습니다.
- 상태 변경 - 성공
![payment_updatestatus_success](https://github.com/user-attachments/assets/d735465c-eca0-4556-a928-e7af062de8a0)

- 상태 변경 - 이상한 상태값
![payment_updateStatus_이상한상태값](https://github.com/user-attachments/assets/4d752c6f-7945-4d97-b4d6-b7a3f68b3707)

- 환불 요청 - 성공
![payment_refund_성공](https://github.com/user-attachments/assets/b48a33ec-f8d8-49c8-b94a-473bec9175d8)

- 환불 할 수 없는 상태 - `COMPLETE`를 제외한 상태는 환불할 수 없는 상태
![payment_refund_환불할수없는상태](https://github.com/user-attachments/assets/4a70f898-9d8b-4dff-bf02-56b8c7ca9f26)


### To Reviewers
- application.yml에 SNAKE_CASE 적용하니까 반영되는거 같습니다. 팀원분들 사용하시면 될 거 같습니다.
```
spring:
  jackson:
    property-naming-strategy: SNAKE_CASE
```
- 개선사항 보이면 자유롭게 말씀해주세요.