### PR TITLE
[Reservation] feat: 예약 상세 조회 - #26

### DIFF
--- a/reservation/http/reservation.http
+++ b/reservation/http/reservation.http
@@ -21,3 +21,7 @@ Content-Type: application/json
 POST localhost:19005/api/v1/reservations/cancel/e47cf394-4a51-416c-a2d7-1b45dd17477b
 Content-Type: application/json
 
+### 예약 상세 조회
+GET localhost:19005/api/v1/reservations/e47cf394-4a51-416c-a2d7-1b45dd17477b
+Content-Type: application/json
+

--- a/reservation/src/main/java/com/bobjool/reservation/application/service/ReservationService.java
+++ b/reservation/src/main/java/com/bobjool/reservation/application/service/ReservationService.java
@@ -63,4 +63,13 @@ public class ReservationService {
         reservation.cancel();
         return ReservationResDto.from(reservation);
     }
+
+    public ReservationResDto getReservation(UUID reservationId) {
+        log.info("getReservation.reservationId = {}", reservationId);
+
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND));
+
+        return ReservationResDto.from(reservation);
+    }
 }

--- a/reservation/src/main/java/com/bobjool/reservation/presentation/controller/ReservationController.java
+++ b/reservation/src/main/java/com/bobjool/reservation/presentation/controller/ReservationController.java
@@ -42,4 +42,11 @@ public class ReservationController {
         ReservationResDto response = reservationService.cancelReservation(reservationId);
         return ApiResponse.success(SuccessCode.SUCCESS, response);
     }
+
+    @GetMapping("/{reservationId}")
+    public ResponseEntity<ApiResponse<ReservationResDto>> getReservation(@PathVariable("reservationId") UUID reservationId) {
+        log.info("getReservation.reservationGetReqDto: {}", reservationId);
+        ReservationResDto response = reservationService.getReservation(reservationId);
+        return ApiResponse.success(SuccessCode.SUCCESS, response);
+    }
 }

--- a/reservation/src/test/java/com/bobjool/reservation/application/service/ReservationServiceTest.java
+++ b/reservation/src/test/java/com/bobjool/reservation/application/service/ReservationServiceTest.java
@@ -204,4 +204,40 @@ class ReservationServiceTest {
                 .hasMessage(ErrorCode.CANNOT_CANCEL.getMessage());
     }
 
+    @DisplayName("getReservation - 성공적으로 예약 정보를 반환한다.")
+    @Test
+    void getReservation_whenReservationExists() {
+        // given - 예약이 존재할 때
+        Reservation reservation = Reservation.create(
+                12345L,
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                5
+        );
+        reservationRepository.save(reservation);
+
+        // when - getReservation 호출
+        ReservationResDto response = reservationService.getReservation(reservation.getId());
+
+        // then - 반환된 예약 정보가 올바른지 확인
+        assertThat(response.reservationId()).isEqualTo(reservation.getId());
+        assertThat(response.userId()).isEqualTo(reservation.getUserId());
+        assertThat(response.restaurantId()).isEqualTo(reservation.getRestaurantId());
+        assertThat(response.restaurantScheduleId()).isEqualTo(reservation.getRestaurantScheduleId());
+        assertThat(response.guestCount()).isEqualTo(reservation.getGuestCount());
+        assertThat(response.status()).isEqualTo(reservation.getStatus().name());
+    }
+
+    @DisplayName("getReservation - 예약이 존재하지 않을 경우 BobJoolException 발생")
+    @Test
+    void getReservation_whenReservationNotFound() {
+        // given - 존재하지 않는 예약 ID
+        UUID nonExistentReservationId = UUID.randomUUID();
+
+        // when & then - 예외 발생 확인
+        assertThatThrownBy(() -> reservationService.getReservation(nonExistentReservationId))
+                .isInstanceOf(BobJoolException.class)
+                .hasMessage(ErrorCode.ENTITY_NOT_FOUND.getMessage());
+    }
+
 }

--- a/reservation/src/test/java/com/bobjool/reservation/presentation/controller/ReservationControllerTest.java
+++ b/reservation/src/test/java/com/bobjool/reservation/presentation/controller/ReservationControllerTest.java
@@ -1,5 +1,6 @@
 package com.bobjool.reservation.presentation.controller;
 
+import com.bobjool.reservation.application.dto.reservation.ReservationResDto;
 import com.bobjool.reservation.application.service.ReservationService;
 import com.bobjool.reservation.presentation.dto.reservation.ReservationCreateReqDto;
 import com.bobjool.reservation.presentation.dto.reservation.ReservationUpdateReqDto;
@@ -14,10 +15,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -181,6 +182,19 @@ class ReservationControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/v1/reservations/cancel/{reservationId}", reservationId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("getReservation - 성공적으로 예약 정보를 반환한다.")
+    @Test
+    void getReservation_success() throws Exception {
+        // given - reservationId
+        UUID reservationId = UUID.randomUUID();
+
+        // when & then - API 호출 및 검증
+        mockMvc.perform(get("/api/v1/reservations/{reservationId}", reservationId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk());


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/reservation-findOne -> dev
### 이슈
- #26 
### Description
- 예약 상세 조회를 구현했습니다.

- 예약 상세 조회 - 성공
![reservation_findOne_성공](https://github.com/user-attachments/assets/f3e96e62-d91a-4037-97c4-2f03160f078d)


- 예약 상세 조회 - 없는 ID - 실패
![reservation_findOne_엔티티없을때](https://github.com/user-attachments/assets/d400e514-b072-4174-9288-bc03fdb50301)


### To Reviewers
- 개선사항 자유롭게 말씀해주세요~