### PR TITLE
[Restaurant] Feat/restaurant lookup api

### DIFF
--- a/restaurant/src/main/java/com/bobjool/restaurant/application/dto/restaurant/RestaurantForCustomerResDto.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/dto/restaurant/RestaurantForCustomerResDto.java
@@ -9,45 +9,29 @@ import java.time.LocalTime;
 import java.util.UUID;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record RestaurantResDto(
-    UUID RestaurantId,
-    Long userId,
+public record RestaurantForCustomerResDto(
     RestaurantCategory restaurantCategory,
     String restaurantPhone,
     String restaurantName,
     RestaurantRegion restaurantRegion,
     String restaurantAddressDetail,
     String restaurantDescription,
-    int restaurantVolume,
-    boolean isReservation,
-    boolean isQueue,
     LocalTime openTime,
     LocalTime closeTime
-//    LocalDateTime createdAt,
-//    LocalDateTime updatedAt
 
 ) {
 
-  public static RestaurantResDto from(Restaurant restaurant){
-    return new RestaurantResDto(
-        restaurant.getId(),
-        restaurant.getUserId(),
+  public static RestaurantForCustomerResDto from(Restaurant restaurant){
+    return new RestaurantForCustomerResDto(
         restaurant.getRestaurantCategory(),
         restaurant.getRestaurantPhone(),
         restaurant.getRestaurantName(),
         restaurant.getRestaurantRegion(),
         restaurant.getRestaurantAddressDetail(),
         restaurant.getRestaurantDescription(),
-        restaurant.getRestaurantVolume(),
-        restaurant.isReservation(),
-        restaurant.isQueue(),
         restaurant.getOpenTime(),
         restaurant.getCloseTime()
-//        restaurant.getCreatedAt(),
-//        restaurant.getUpdatedAt()
     );
   }
-
-
 
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/dto/restaurant/RestaurantForMasterResDto.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/dto/restaurant/RestaurantForMasterResDto.java
@@ -5,11 +5,12 @@ import com.bobjool.restaurant.domain.entity.restaurant.RestaurantCategory;
 import com.bobjool.restaurant.domain.entity.restaurant.RestaurantRegion;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record RestaurantResDto(
+public record RestaurantForMasterResDto(
     UUID RestaurantId,
     Long userId,
     RestaurantCategory restaurantCategory,
@@ -22,14 +23,18 @@ public record RestaurantResDto(
     boolean isReservation,
     boolean isQueue,
     LocalTime openTime,
-    LocalTime closeTime
-//    LocalDateTime createdAt,
-//    LocalDateTime updatedAt
-
+    LocalTime closeTime,
+    LocalDateTime createdAt,
+    String createdBy,
+    LocalDateTime updatedAt,
+    String updatedBy,
+    LocalDateTime deletedAt,
+    String deletedBy,
+    boolean isDeleted
 ) {
 
-  public static RestaurantResDto from(Restaurant restaurant){
-    return new RestaurantResDto(
+  public static RestaurantForMasterResDto from(Restaurant restaurant){
+    return new RestaurantForMasterResDto(
         restaurant.getId(),
         restaurant.getUserId(),
         restaurant.getRestaurantCategory(),
@@ -42,9 +47,14 @@ public record RestaurantResDto(
         restaurant.isReservation(),
         restaurant.isQueue(),
         restaurant.getOpenTime(),
-        restaurant.getCloseTime()
-//        restaurant.getCreatedAt(),
-//        restaurant.getUpdatedAt()
+        restaurant.getCloseTime(),
+        restaurant.getCreatedAt(),
+        restaurant.getCreatedBy(),
+        restaurant.getUpdatedAt(),
+        restaurant.getUpdatedBy(),
+        restaurant.getDeletedAt(),
+        restaurant.getDeletedBy(),
+        restaurant.getIsDeleted()
     );
   }
 

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/dto/restaurantSchedule/RestaurantScheduleForCustomerResDto.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/dto/restaurantSchedule/RestaurantScheduleForCustomerResDto.java
@@ -1,0 +1,30 @@
+package com.bobjool.restaurant.application.dto.restaurantSchedule;
+
+import com.bobjool.restaurant.domain.entity.restaurantSchedule.RestaurantSchedule;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record RestaurantScheduleForCustomerResDto(
+    UUID restaurantId,
+    int tableNumber,
+    LocalDate date,
+    LocalTime timeSlot,
+    int currentCapacity
+
+) {
+
+  public static RestaurantScheduleForCustomerResDto from(RestaurantSchedule restaurantSchedule){
+    return new RestaurantScheduleForCustomerResDto(
+        restaurantSchedule.getRestaurantId(),
+        restaurantSchedule.getTableNumber(),
+        restaurantSchedule.getDate(),
+        restaurantSchedule.getTimeSlot(),
+        restaurantSchedule.getCurrentCapacity()
+    );
+  }
+
+}

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/dto/restaurantSchedule/RestaurantScheduleReserveDto.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/dto/restaurantSchedule/RestaurantScheduleReserveDto.java
@@ -1,14 +1,7 @@
 package com.bobjool.restaurant.application.dto.restaurantSchedule;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.UUID;
-
 public record RestaurantScheduleReserveDto(
     Long userId,
-    int tableNumber,
-    LocalDate date,
-    LocalTime timeSlot,
     int currentCapacity
 ) {
 

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/dto/restaurantSchedule/RestaurantScheduleUpdateDto.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/dto/restaurantSchedule/RestaurantScheduleUpdateDto.java
@@ -2,7 +2,6 @@ package com.bobjool.restaurant.application.dto.restaurantSchedule;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.UUID;
 
 public record RestaurantScheduleUpdateDto(
   Long userId,

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurant/RestaurantService.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurant/RestaurantService.java
@@ -9,6 +9,7 @@ import com.bobjool.restaurant.application.dto.restaurant.RestaurantResDto;
 import com.bobjool.restaurant.application.dto.restaurant.RestaurantUpdateDto;
 import com.bobjool.restaurant.domain.entity.restaurant.Restaurant;
 import com.bobjool.restaurant.domain.repository.RestaurantRepository;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -125,6 +126,28 @@ public class RestaurantService {
     return RestaurantForMasterResDto.from(restaurant);
   }
 
+  public RestaurantResDto isReservation(UUID restaurantId, boolean isReservation) {
+    log.info("isReservation={}", isReservation);
+
+    Restaurant restaurant = restaurantRepository.findById(restaurantId)
+        .orElseThrow(() -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND));
+
+    restaurant.isReservation(isReservation);
+
+    return RestaurantResDto.from(restaurant);
+  }
+
+  public RestaurantResDto isQueue(UUID restaurantId, boolean isQueue) {
+    log.info("isQueue={}", isQueue);
+
+    Restaurant restaurant = restaurantRepository.findById(restaurantId)
+        .orElseThrow(() -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND));
+
+    restaurant.isQueue(isQueue);
+
+    return RestaurantResDto.from(restaurant);
+  }
+
   private void validateDuplicate(RestaurantCreateDto restaurantCreateDto) {
     if (restaurantRepository.findByRestaurantName(restaurantCreateDto.restaurantName())
         .isPresent()) {
@@ -155,5 +178,6 @@ public class RestaurantService {
       throw new BobJoolException(ErrorCode.DUPPLICATED_Address);
     }
   }
+
 
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurant/RestaurantService.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurant/RestaurantService.java
@@ -3,6 +3,8 @@ package com.bobjool.restaurant.application.service.restaurant;
 import com.bobjool.common.exception.BobJoolException;
 import com.bobjool.common.exception.ErrorCode;
 import com.bobjool.restaurant.application.dto.restaurant.RestaurantCreateDto;
+import com.bobjool.restaurant.application.dto.restaurant.RestaurantForCustomerResDto;
+import com.bobjool.restaurant.application.dto.restaurant.RestaurantForMasterResDto;
 import com.bobjool.restaurant.application.dto.restaurant.RestaurantResDto;
 import com.bobjool.restaurant.application.dto.restaurant.RestaurantUpdateDto;
 import com.bobjool.restaurant.domain.entity.restaurant.Restaurant;
@@ -58,11 +60,11 @@ public class RestaurantService {
 
     restaurant.update(restaurantUpdateDto);
 
-  return RestaurantResDto.from(restaurant);
+    return RestaurantResDto.from(restaurant);
   }
 
   @Transactional
-  public void deleteRestaurant(UUID Id){
+  public void deleteRestaurant(UUID Id) {
     log.info("DeleteRestaurant");
 
     Restaurant restaurant = restaurantRepository.findById(Id)
@@ -71,8 +73,9 @@ public class RestaurantService {
     restaurant.deleteBase(restaurant.getUserId());
   }
 
+  //음식점 모든 정보 전체 조회
   @Transactional(readOnly = true)
-  public Page<RestaurantResDto> AllRestaurants(Pageable pageable){
+  public Page<RestaurantResDto> AllRestaurants(Pageable pageable) {
     log.info("All Restaurant info");
 
     Page<Restaurant> restaurantPage = restaurantRepository.findAllByIsDeletedFalse(pageable);
@@ -80,23 +83,77 @@ public class RestaurantService {
     return restaurantPage.map(RestaurantResDto::from);
   }
 
-    private void validateDuplicate(RestaurantCreateDto restaurantCreateDto) {
-    if(restaurantRepository.findByRestaurantName(restaurantCreateDto.restaurantName()).isPresent())
-      throw new BobJoolException(ErrorCode.DUPLICATED_NAME);
-    if(restaurantRepository.findByRestaurantPhone(restaurantCreateDto.restaurantPhone()).isPresent())
-      throw new BobJoolException(ErrorCode.DUPLICATED_PHONE);
-    if(restaurantRepository.findByRestaurantAddressDetail(restaurantCreateDto.restaurantAddressDetail()).isPresent())
-      throw new BobJoolException(ErrorCode.DUPPLICATED_Address);
+  //삭제된 음식점 정보 전체 조회
+  @Transactional(readOnly = true)
+  public Page<RestaurantResDto> DeletedRestaurants(Pageable pageable) {
+    log.info("Deleted Restaurant info");
+
+    Page<Restaurant> restaurantPage = restaurantRepository.findAllByIsDeletedTrue(pageable);
+
+    return restaurantPage.map(RestaurantResDto::from);
   }
 
-//  Update 임시 예외처리로 Create와 공용사용중. 추후 세분화(바꾸기 이전 값을 따로 예외처리)
-  private void validateDuplicate(RestaurantUpdateDto restaurantUpdateDto) {
-    if(restaurantRepository.findByRestaurantName(restaurantUpdateDto.restaurantName()).isPresent())
+
+  //단일 음식점 정보 조회 For Owner
+  @Transactional(readOnly = true)
+  public RestaurantForCustomerResDto getRestaurantsForCustomer(UUID id) {
+    log.info("All Restaurant info");
+
+    Restaurant restaurant = restaurantRepository.findById(id)
+        .orElseThrow(() -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND));
+
+    return RestaurantForCustomerResDto.from(restaurant);
+  }
+
+  @Transactional(readOnly = true)
+  public RestaurantResDto getRestaurantsForOwner(UUID id) {
+    log.info("All Restaurant info");
+
+    Restaurant restaurant = restaurantRepository.findById(id)
+        .orElseThrow(() -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND));
+
+    return RestaurantResDto.from(restaurant);
+  }
+
+  @Transactional(readOnly = true)
+  public RestaurantForMasterResDto getRestaurantsForMaster(UUID id) {
+    log.info("All Restaurant info");
+
+    Restaurant restaurant = restaurantRepository.findById(id)
+        .orElseThrow(() -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND));
+
+    return RestaurantForMasterResDto.from(restaurant);
+  }
+
+  private void validateDuplicate(RestaurantCreateDto restaurantCreateDto) {
+    if (restaurantRepository.findByRestaurantName(restaurantCreateDto.restaurantName())
+        .isPresent()) {
       throw new BobJoolException(ErrorCode.DUPLICATED_NAME);
-    if(restaurantRepository.findByRestaurantPhone(restaurantUpdateDto.restaurantPhone()).isPresent())
+    }
+    if (restaurantRepository.findByRestaurantPhone(restaurantCreateDto.restaurantPhone())
+        .isPresent()) {
       throw new BobJoolException(ErrorCode.DUPLICATED_PHONE);
-    if(restaurantRepository.findByRestaurantAddressDetail(restaurantUpdateDto.restaurantAddressDetail()).isPresent())
+    }
+    if (restaurantRepository.findByRestaurantAddressDetail(
+        restaurantCreateDto.restaurantAddressDetail()).isPresent()) {
       throw new BobJoolException(ErrorCode.DUPPLICATED_Address);
+    }
+  }
+
+  //  Update 임시 예외처리로 Create와 공용사용중. 추후 세분화(바꾸기 이전 값을 따로 예외처리)
+  private void validateDuplicate(RestaurantUpdateDto restaurantUpdateDto) {
+    if (restaurantRepository.findByRestaurantName(restaurantUpdateDto.restaurantName())
+        .isPresent()) {
+      throw new BobJoolException(ErrorCode.DUPLICATED_NAME);
+    }
+    if (restaurantRepository.findByRestaurantPhone(restaurantUpdateDto.restaurantPhone())
+        .isPresent()) {
+      throw new BobJoolException(ErrorCode.DUPLICATED_PHONE);
+    }
+    if (restaurantRepository.findByRestaurantAddressDetail(
+        restaurantUpdateDto.restaurantAddressDetail()).isPresent()) {
+      throw new BobJoolException(ErrorCode.DUPPLICATED_Address);
+    }
   }
 
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurant/RestaurantService.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurant/RestaurantService.java
@@ -9,7 +9,6 @@ import com.bobjool.restaurant.application.dto.restaurant.RestaurantResDto;
 import com.bobjool.restaurant.application.dto.restaurant.RestaurantUpdateDto;
 import com.bobjool.restaurant.domain.entity.restaurant.Restaurant;
 import com.bobjool.restaurant.domain.repository.RestaurantRepository;
-import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -76,7 +75,7 @@ public class RestaurantService {
 
   //음식점 모든 정보 전체 조회
   @Transactional(readOnly = true)
-  public Page<RestaurantResDto> AllRestaurants(Pageable pageable) {
+  public Page<RestaurantResDto> readRestaurants(Pageable pageable) {
     log.info("All Restaurant info");
 
     Page<Restaurant> restaurantPage = restaurantRepository.findAllByIsDeletedFalse(pageable);
@@ -86,7 +85,7 @@ public class RestaurantService {
 
   //삭제된 음식점 정보 전체 조회
   @Transactional(readOnly = true)
-  public Page<RestaurantResDto> DeletedRestaurants(Pageable pageable) {
+  public Page<RestaurantResDto> deletedRestaurants(Pageable pageable) {
     log.info("Deleted Restaurant info");
 
     Page<Restaurant> restaurantPage = restaurantRepository.findAllByIsDeletedTrue(pageable);
@@ -97,7 +96,7 @@ public class RestaurantService {
 
   //단일 음식점 정보 조회 For Owner
   @Transactional(readOnly = true)
-  public RestaurantForCustomerResDto getRestaurantsForCustomer(UUID id) {
+  public RestaurantForCustomerResDto readRestaurantsForCustomer(UUID id) {
     log.info("All Restaurant info");
 
     Restaurant restaurant = restaurantRepository.findById(id)
@@ -107,7 +106,7 @@ public class RestaurantService {
   }
 
   @Transactional(readOnly = true)
-  public RestaurantResDto getRestaurantsForOwner(UUID id) {
+  public RestaurantResDto readRestaurantsForOwner(UUID id) {
     log.info("All Restaurant info");
 
     Restaurant restaurant = restaurantRepository.findById(id)
@@ -117,7 +116,7 @@ public class RestaurantService {
   }
 
   @Transactional(readOnly = true)
-  public RestaurantForMasterResDto getRestaurantsForMaster(UUID id) {
+  public RestaurantForMasterResDto readRestaurantsForMaster(UUID id) {
     log.info("All Restaurant info");
 
     Restaurant restaurant = restaurantRepository.findById(id)
@@ -126,6 +125,7 @@ public class RestaurantService {
     return RestaurantForMasterResDto.from(restaurant);
   }
 
+  @Transactional
   public RestaurantResDto isReservation(UUID restaurantId, boolean isReservation) {
     log.info("isReservation={}", isReservation);
 
@@ -136,7 +136,7 @@ public class RestaurantService {
 
     return RestaurantResDto.from(restaurant);
   }
-
+  @Transactional
   public RestaurantResDto isQueue(UUID restaurantId, boolean isQueue) {
     log.info("isQueue={}", isQueue);
 

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
@@ -49,11 +49,14 @@ public class RestaurantScheduleService {
     RestaurantSchedule restaurantSchedule = scheduleRepository.findById(scheduleId)
         .orElseThrow(() -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND));
 
-    if(restaurantSchedule.getMaxCapacity() < scheduleReserveDto.currentCapacity()){
+    if(!restaurantSchedule.isCapacityExceeded(
+        scheduleReserveDto.currentCapacity())){
       log.info("restaurantSchedule.getMaxCapacity = {}", restaurantSchedule.getMaxCapacity());
       log.info("scheduleUpdateDto.currentCapacity = {}", scheduleReserveDto.currentCapacity());
       throw new BobJoolException(ErrorCode.CAPACITY_OVERFLOW);
     }
+
+
     if(!restaurantSchedule.isAvailable()){
       throw new BobJoolException(ErrorCode.ALREADEY_RESERVED);
     }

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
@@ -8,6 +8,8 @@ import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantSched
 import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleUpdateDto;
 import com.bobjool.restaurant.domain.entity.restaurantSchedule.RestaurantSchedule;
 import com.bobjool.restaurant.domain.repository.RestaurantScheduleRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,7 +62,12 @@ public class RestaurantScheduleService {
     if(!restaurantSchedule.isAvailable()){
       throw new BobJoolException(ErrorCode.ALREADEY_RESERVED);
     }
-    restaurantSchedule.reserve(scheduleReserveDto);
+    restaurantSchedule.reserve(
+        scheduleReserveDto.userId(),
+        scheduleReserveDto.date(),
+        scheduleReserveDto.timeSlot(),
+        scheduleReserveDto.currentCapacity()
+    );
     return RestaurantScheduleResDto.from(restaurantSchedule);
   }
 
@@ -72,7 +79,16 @@ public class RestaurantScheduleService {
     RestaurantSchedule restaurantSchedule = scheduleRepository.findById(scheduleId)
         .orElseThrow(() -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND));
 
-    restaurantSchedule.update(scheduleUpdateDto);
+    restaurantSchedule.update(
+        scheduleUpdateDto.userId(),
+        scheduleUpdateDto.date(),
+        scheduleUpdateDto.timeSlot(),
+        scheduleUpdateDto.maxCapacity(),
+        scheduleUpdateDto.currentCapacity(),
+        scheduleUpdateDto.available()
+    );
+
+
 
     return RestaurantScheduleResDto.from(restaurantSchedule);
   }

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
@@ -122,5 +122,11 @@ public class RestaurantScheduleService {
   }
 
 
+  public Page<RestaurantScheduleResDto> findAllByRestaurantIdAndDate(UUID restaurantId, LocalDate date, Pageable pageable) {
+    log.info("All RestaurantSchedule info");
 
+    Page<RestaurantSchedule> SchedulePage = scheduleRepository.findAllByRestaurantIdAndDate(restaurantId, date, pageable);
+
+    return SchedulePage.map(RestaurantScheduleResDto::from);
+  }
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
@@ -121,4 +121,6 @@ public class RestaurantScheduleService {
     return SchedulePage.map(RestaurantScheduleResDto::from);
   }
 
+
+
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
@@ -3,6 +3,7 @@ package com.bobjool.restaurant.application.service.restaurantSchedule;
 import com.bobjool.common.exception.BobJoolException;
 import com.bobjool.common.exception.ErrorCode;
 import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleCreateDto;
+import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleForCustomerResDto;
 import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleResDto;
 import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleReserveDto;
 import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleUpdateDto;
@@ -114,14 +115,14 @@ public class RestaurantScheduleService {
 
   @Transactional(readOnly = true)
   public Page<RestaurantScheduleResDto> readForOneRestaurant(UUID id, Pageable pageable) {
-    log.info("All RestaurantSchedule info");
+    log.info("RestaurantSchedule info");
 
     Page<RestaurantSchedule> SchedulePage = scheduleRepository.findAllByRestaurantId(id, pageable);
 
     return SchedulePage.map(RestaurantScheduleResDto::from);
   }
 
-
+  @Transactional(readOnly = true)
   public Page<RestaurantScheduleResDto> findAllByRestaurantIdAndDate(UUID restaurantId,
       LocalDate date, Pageable pageable) {
     log.info("All RestaurantSchedule info");
@@ -166,5 +167,14 @@ public class RestaurantScheduleService {
         restaurant.getId(), date, pageable);
 
     return SchedulePage.map(RestaurantScheduleResDto::from);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<RestaurantScheduleForCustomerResDto> readForUserReserve(Long userId, Pageable pageable) {
+    log.info("RestaurantSchedule info");
+
+    Page<RestaurantSchedule> SchedulePage = scheduleRepository.findAllByUserId(userId, pageable);
+
+    return SchedulePage.map(RestaurantScheduleForCustomerResDto::from);
   }
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/application/service/restaurantSchedule/RestaurantScheduleService.java
@@ -12,15 +12,11 @@ import com.bobjool.restaurant.domain.repository.RestaurantRepository;
 import com.bobjool.restaurant.domain.repository.RestaurantScheduleRepository;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort.Direction;
-import org.springframework.data.web.SortDefault;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,8 +67,6 @@ public class RestaurantScheduleService {
     }
     restaurantSchedule.reserve(
         scheduleReserveDto.userId(),
-        scheduleReserveDto.date(),
-        scheduleReserveDto.timeSlot(),
         scheduleReserveDto.currentCapacity()
     );
     return RestaurantScheduleResDto.from(restaurantSchedule);

--- a/restaurant/src/main/java/com/bobjool/restaurant/domain/entity/restaurant/Restaurant.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/domain/entity/restaurant/Restaurant.java
@@ -113,4 +113,12 @@ public class Restaurant extends BaseEntity {
     this.closeTime = restaurantUpdateDto.closeTime();
   }
 
+  public void isReservation(boolean isReservation){
+    this.isReservation = isReservation;
+  }
+
+  public void isQueue(boolean isQueue){
+    this.isQueue = isQueue;
+  }
+
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/domain/entity/restaurantSchedule/RestaurantSchedule.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/domain/entity/restaurantSchedule/RestaurantSchedule.java
@@ -2,7 +2,6 @@ package com.bobjool.restaurant.domain.entity.restaurantSchedule;
 
 
 import com.bobjool.common.domain.entity.BaseEntity;
-import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleUpdateDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -80,14 +79,11 @@ public class RestaurantSchedule extends BaseEntity {
   //Customer가 좌석 예약
   public void reserve(
       Long userId,
-      LocalDate date,
-      LocalTime timeSlot,
       int currentCapacity
   ){
       this.userId = userId;
-      this.date = date;
-      this.timeSlot = timeSlot;
       this.currentCapacity = currentCapacity;
+      this.available = false;
   }
 
   //Owner가 스케쥴에 대한 정보를 수정

--- a/restaurant/src/main/java/com/bobjool/restaurant/domain/entity/restaurantSchedule/RestaurantSchedule.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/domain/entity/restaurantSchedule/RestaurantSchedule.java
@@ -97,4 +97,13 @@ public class RestaurantSchedule extends BaseEntity {
     this.available = scheduleUpdateDto.available();
   }
 
+  /**
+   * 예약 가능 여부를 확인하는 메서드
+   * @param requestedCapacity 요청된 추가 예약 인원
+   * @return true: 수용 가능, false: 초과
+   */
+  public boolean isCapacityExceeded(int requestedCapacity) {
+    return this.maxCapacity > requestedCapacity;
+  }
+
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/domain/entity/restaurantSchedule/RestaurantSchedule.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/domain/entity/restaurantSchedule/RestaurantSchedule.java
@@ -2,7 +2,6 @@ package com.bobjool.restaurant.domain.entity.restaurantSchedule;
 
 
 import com.bobjool.common.domain.entity.BaseEntity;
-import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleReserveDto;
 import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleUpdateDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -79,22 +78,33 @@ public class RestaurantSchedule extends BaseEntity {
   }
 
   //Customer가 좌석 예약
-  public void reserve(RestaurantScheduleReserveDto scheduleReserveDto){
-    this.userId = scheduleReserveDto.userId();
-    this.date = scheduleReserveDto.date(); // 있는지 조회만
-    this.timeSlot = scheduleReserveDto.timeSlot(); // 있는지 조회만
-    this.currentCapacity = scheduleReserveDto.currentCapacity();
-    this.available = false;
+  public void reserve(
+      Long userId,
+      LocalDate date,
+      LocalTime timeSlot,
+      int currentCapacity
+  ){
+      this.userId = userId;
+      this.date = date;
+      this.timeSlot = timeSlot;
+      this.currentCapacity = currentCapacity;
   }
 
   //Owner가 스케쥴에 대한 정보를 수정
-  public void update(RestaurantScheduleUpdateDto scheduleUpdateDto){
-    this.userId = scheduleUpdateDto.userId();
-    this.date = scheduleUpdateDto.date(); // 있는지 조회만
-    this.timeSlot = scheduleUpdateDto.timeSlot(); // 있는지 조회만
-    this.maxCapacity = scheduleUpdateDto.maxCapacity();
-    this.currentCapacity = scheduleUpdateDto.currentCapacity();
-    this.available = scheduleUpdateDto.available();
+  public void update(
+    Long userId,
+    LocalDate date,
+    LocalTime timeSlot,
+    int maxCapacity,
+    int currentCapacity,
+    boolean available
+  ){
+    this.userId = userId;
+    this.date = date;
+    this.timeSlot = timeSlot;
+    this.maxCapacity = maxCapacity;
+    this.currentCapacity = currentCapacity;
+    this.available = available;
   }
 
   /**

--- a/restaurant/src/main/java/com/bobjool/restaurant/domain/repository/RestaurantRepository.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/domain/repository/RestaurantRepository.java
@@ -23,6 +23,8 @@ public interface RestaurantRepository {
 
   Page<Restaurant> findAllByIsDeletedFalse(Pageable pageable);
 
+  Page<Restaurant> findAllByIsDeletedTrue(Pageable pageable);
+
   // todo 직접 만든 메서드는 테스트 해봐야 합니다.
 
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/domain/repository/RestaurantScheduleRepository.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/domain/repository/RestaurantScheduleRepository.java
@@ -18,4 +18,8 @@ public interface RestaurantScheduleRepository {
   Page<RestaurantSchedule> findAllByRestaurantId(UUID restaurantId, Pageable pageable);
 
   Page<RestaurantSchedule> findAllByRestaurantIdAndDate(UUID restaurantId, LocalDate date, Pageable pageable);
+
+  Page<RestaurantSchedule> findAllByUserId(Long userId, Pageable pageable);
+
+
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/domain/repository/RestaurantScheduleRepository.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/domain/repository/RestaurantScheduleRepository.java
@@ -1,6 +1,7 @@
 package com.bobjool.restaurant.domain.repository;
 
 import com.bobjool.restaurant.domain.entity.restaurantSchedule.RestaurantSchedule;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -15,4 +16,6 @@ public interface RestaurantScheduleRepository {
   Page<RestaurantSchedule> findAllByIsDeletedFalse(Pageable pageable);
 
   Page<RestaurantSchedule> findAllByRestaurantId(UUID restaurantId, Pageable pageable);
+
+  Page<RestaurantSchedule> findAllByRestaurantIdAndDate(UUID restaurantId, LocalDate date, Pageable pageable);
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurant/RestaurantController.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurant/RestaurantController.java
@@ -14,7 +14,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.SortDefault;
@@ -92,7 +91,7 @@ public class RestaurantController {
     log.info("getAllRestaurants");
 
     Page<RestaurantResDto> resPage
-        = restaurantService.AllRestaurants(pageable);
+        = restaurantService.readRestaurants(pageable);
     return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
   }
 
@@ -104,7 +103,7 @@ public class RestaurantController {
     log.info("getDeletedRestaurants");
 
     Page<RestaurantResDto> resPage
-        = restaurantService.DeletedRestaurants(pageable);
+        = restaurantService.deletedRestaurants(pageable);
     return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
   }
 
@@ -116,7 +115,7 @@ public class RestaurantController {
       @Valid @PathVariable("restaurantId") UUID restaurantId) {
     log.info("getAllRestaurants");
 
-    RestaurantResDto response = restaurantService.getRestaurantsForOwner(restaurantId);
+    RestaurantResDto response = restaurantService.readRestaurantsForOwner(restaurantId);
     return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
   }
 
@@ -126,7 +125,7 @@ public class RestaurantController {
       @Valid @PathVariable("restaurantId") UUID restaurantId) {
     log.info("getAllRestaurants");
 
-    RestaurantForCustomerResDto response = restaurantService.getRestaurantsForCustomer(restaurantId);
+    RestaurantForCustomerResDto response = restaurantService.readRestaurantsForCustomer(restaurantId);
     return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
   }
   //단일 음식점 정보 조회(for Master)
@@ -135,7 +134,7 @@ public class RestaurantController {
       @Valid @PathVariable("restaurantId") UUID restaurantId) {
     log.info("getAllRestaurants");
 
-    RestaurantForMasterResDto response = restaurantService.getRestaurantsForMaster(restaurantId);
+    RestaurantForMasterResDto response = restaurantService.readRestaurantsForMaster(restaurantId);
     return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
   }
 

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurant/RestaurantController.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurant/RestaurantController.java
@@ -21,6 +21,7 @@ import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -53,6 +54,24 @@ public class RestaurantController {
     log.info("update.RestaurantUpdateReqDto={}", restaurantUpdateReqDto);
     RestaurantResDto response = restaurantService.updateRestaurant(restaurantId,
         restaurantUpdateReqDto.toServiceDto());
+    return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
+  }
+
+  @PutMapping("/is-reservation/{restaurantId}")
+  public ResponseEntity<ApiResponse<RestaurantResDto>> restaurantReservationChange(
+      @Valid @RequestParam boolean isReservation,
+      @PathVariable("restaurantId") UUID restaurantId) {
+    log.info("isReservation={}", isReservation);
+    RestaurantResDto response = restaurantService.isReservation(restaurantId, isReservation);
+    return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
+  }
+
+  @PutMapping("/is-queue/{restaurantId}")
+  public ResponseEntity<ApiResponse<RestaurantResDto>> restaurantQueueChange(
+      @Valid @RequestParam boolean isQueue,
+      @PathVariable("restaurantId") UUID restaurantId) {
+    log.info("isQueue={}", isQueue);
+    RestaurantResDto response = restaurantService.isQueue(restaurantId, isQueue);
     return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
   }
 
@@ -119,6 +138,8 @@ public class RestaurantController {
     RestaurantForMasterResDto response = restaurantService.getRestaurantsForMaster(restaurantId);
     return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
   }
+
+
 
 
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurant/RestaurantController.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurant/RestaurantController.java
@@ -65,16 +65,12 @@ public class RestaurantController {
 
   @GetMapping
   public ResponseEntity<ApiResponse<PageResponse<RestaurantResDto>>> getAllRestaurants(
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "10") int size,
       @SortDefault(sort = "createdAt", direction = Direction.DESC)
       Pageable pageable) {
     log.info("getAllRestaurants");
 
-    Pageable AllRestaurantPageable = PageRequest.of(page, size, pageable.getSort());
-
     Page<RestaurantResDto> resPage
-        = restaurantService.AllRestaurants(AllRestaurantPageable);
+        = restaurantService.AllRestaurants(pageable);
     return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
 
   }

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurant/RestaurantController.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurant/RestaurantController.java
@@ -3,6 +3,8 @@ package com.bobjool.restaurant.presentation.controller.restaurant;
 import com.bobjool.common.presentation.ApiResponse;
 import com.bobjool.common.presentation.PageResponse;
 import com.bobjool.common.presentation.SuccessCode;
+import com.bobjool.restaurant.application.dto.restaurant.RestaurantForCustomerResDto;
+import com.bobjool.restaurant.application.dto.restaurant.RestaurantForMasterResDto;
 import com.bobjool.restaurant.application.dto.restaurant.RestaurantResDto;
 import com.bobjool.restaurant.application.service.restaurant.RestaurantService;
 import com.bobjool.restaurant.presentation.dto.restaurant.RestaurantCreateReqDto;
@@ -63,6 +65,7 @@ public class RestaurantController {
     return ApiResponse.success(SuccessCode.SUCCESS_DELETE);
   }
 
+  //모든 음식점 정보 전체 조회
   @GetMapping
   public ResponseEntity<ApiResponse<PageResponse<RestaurantResDto>>> getAllRestaurants(
       @SortDefault(sort = "createdAt", direction = Direction.DESC)
@@ -72,7 +75,50 @@ public class RestaurantController {
     Page<RestaurantResDto> resPage
         = restaurantService.AllRestaurants(pageable);
     return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
-
   }
+
+  //삭제된 음식점 정보 전체 조회
+  @GetMapping("/deleted")
+  public ResponseEntity<ApiResponse<PageResponse<RestaurantResDto>>> getDeletedRestaurants(
+      @SortDefault(sort = "createdAt", direction = Direction.DESC)
+      Pageable pageable) {
+    log.info("getDeletedRestaurants");
+
+    Page<RestaurantResDto> resPage
+        = restaurantService.DeletedRestaurants(pageable);
+    return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
+  }
+
+  //음식점 정보 검색
+
+  //단일 음식점 정보 조회(for Owner)
+  @GetMapping("/{restaurantId}")
+  public ResponseEntity<ApiResponse<RestaurantResDto>> getRestaurantsForOwner(
+      @Valid @PathVariable("restaurantId") UUID restaurantId) {
+    log.info("getAllRestaurants");
+
+    RestaurantResDto response = restaurantService.getRestaurantsForOwner(restaurantId);
+    return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
+  }
+
+  //단일 음식점 정보 조회(for Owner)
+  @GetMapping("/customer/{restaurantId}")
+  public ResponseEntity<ApiResponse<RestaurantForCustomerResDto>> getRestaurantsForCustomer(
+      @Valid @PathVariable("restaurantId") UUID restaurantId) {
+    log.info("getAllRestaurants");
+
+    RestaurantForCustomerResDto response = restaurantService.getRestaurantsForCustomer(restaurantId);
+    return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
+  }
+  //단일 음식점 정보 조회(for Master)
+  @GetMapping("/master/{restaurantId}")
+  public ResponseEntity<ApiResponse<RestaurantForMasterResDto>> getRestaurantsForMaster(
+      @Valid @PathVariable("restaurantId") UUID restaurantId) {
+    log.info("getAllRestaurants");
+
+    RestaurantForMasterResDto response = restaurantService.getRestaurantsForMaster(restaurantId);
+    return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
+  }
+
 
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
@@ -9,6 +9,7 @@ import com.bobjool.restaurant.presentation.dto.restaurantSchedule.RestaurantSche
 import com.bobjool.restaurant.presentation.dto.restaurantSchedule.RestaurantScheduleReserveReqDto;
 import com.bobjool.restaurant.presentation.dto.restaurantSchedule.RestaurantScheduleUpdateReqDto;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -80,7 +81,7 @@ public class RestaurantScheduleController {
 
   //모든 생성된 음식점 스케쥴 전체 조회
   @GetMapping
-  public ResponseEntity<ApiResponse<PageResponse<RestaurantScheduleResDto>>> getAllSchedule(
+  public ResponseEntity<ApiResponse<PageResponse<RestaurantScheduleResDto>>> readAllSchedule(
       @SortDefault(sort = "createdAt", direction = Direction.DESC)
       Pageable pageable) {
     log.info("getAllRestaurantsSchedule");
@@ -103,4 +104,20 @@ public class RestaurantScheduleController {
         = scheduleService.readForOneRestaurant(restaurantId, pageable);
     return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
   }
+
+  //특정 음식점 날짜 스케쥴 전체 조회
+  @GetMapping("/{restaurantId}/{date}")
+  public ResponseEntity<ApiResponse<PageResponse<RestaurantScheduleResDto>>> readByRestaurantIdAndDate(
+      @SortDefault(sort = "createdAt", direction = Direction.DESC)
+      Pageable pageable,
+      @PathVariable("restaurantId") UUID restaurantId,
+      @PathVariable("date") LocalDate date
+      ) {
+    log.info("getAllRestaurants");
+
+    Page<RestaurantScheduleResDto> resPage
+        = scheduleService.findAllByRestaurantIdAndDate(restaurantId, date, pageable);
+    return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
+  }
+
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
@@ -14,7 +14,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.SortDefault;
@@ -26,7 +25,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -48,34 +46,34 @@ public class RestaurantScheduleController {
   }
 
   //생성된 음식점 스케쥴을 Customer가 예약
-  @PatchMapping("/{ScheduleId}")
+  @PatchMapping("/{scheduleId}")
   public ResponseEntity<ApiResponse<RestaurantScheduleResDto>> reserveSchedule(
       @Valid @RequestBody RestaurantScheduleReserveReqDto scheduleReserveReqDto,
-      @PathVariable("ScheduleId") UUID ScheduleId) {
+      @PathVariable("scheduleId") UUID scheduleId) {
     log.info("update.RestaurantUpdateReqDto={}", scheduleReserveReqDto);
-    RestaurantScheduleResDto response = scheduleService.reserveSchedule(ScheduleId,
+    RestaurantScheduleResDto response = scheduleService.reserveSchedule(scheduleId,
         scheduleReserveReqDto.toServiceDto());
     return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
   }
 
   //음식점 스케쥴 Owner가 수정
-  @PatchMapping("/owner/{ScheduleId}")
+  @PatchMapping("/owner/{scheduleId}")
   public ResponseEntity<ApiResponse<RestaurantScheduleResDto>> updateSchedule(
       @Valid @RequestBody RestaurantScheduleUpdateReqDto scheduleUpdateReqDto,
-      @PathVariable("ScheduleId") UUID ScheduleId) {
+      @PathVariable("scheduleId") UUID scheduleId) {
     log.info("update.RestaurantScheduleUpdateReqDto={}", scheduleUpdateReqDto);
-    RestaurantScheduleResDto response = scheduleService.updateSchedule(ScheduleId,
+    RestaurantScheduleResDto response = scheduleService.updateSchedule(scheduleId,
         scheduleUpdateReqDto.toServiceDto());
     return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);
   }
 
   //음식점 스케쥴 삭제
-  @DeleteMapping("/owner/{ScheduleId}")
+  @DeleteMapping("/owner/{scheduleId}")
   public ResponseEntity<ApiResponse<RestaurantScheduleResDto>> deleteSchedule(
-      @Valid @PathVariable("ScheduleId") UUID ScheduleId) {
+      @Valid @PathVariable("scheduleId") UUID scheduleId) {
 
     log.info("RestaurantDelete");
-    scheduleService.deleteSchedule(ScheduleId);
+    scheduleService.deleteSchedule(scheduleId);
     return ApiResponse.success(SuccessCode.SUCCESS_DELETE);
   }
 

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
@@ -120,4 +120,17 @@ public class RestaurantScheduleController {
     return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
   }
 
+  //음식점 다음주 스케쥴 슬롯 생성
+  //음식점 스케쥴 생성 예정
+  @PostMapping("/DailySchedule")
+  public ResponseEntity<ApiResponse<PageResponse<RestaurantScheduleResDto>>> createDailySchedule(
+      @Valid @RequestBody RestaurantScheduleCreateReqDto scheduleCreateReqDto
+      ) {
+    log.info("DailySchedule.RestaurantScheduleCreateReqDto={}", scheduleCreateReqDto);
+    log.info("DailySchedule.date={}", scheduleCreateReqDto.timeSlot());
+    Page<RestaurantScheduleResDto> response = scheduleService.createDailySchedule(2, scheduleCreateReqDto.date(),
+        scheduleCreateReqDto.toServiceDto());
+    return ApiResponse.success(SuccessCode.SUCCESS_INSERT, PageResponse.of(response));
+  }
+
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
@@ -81,16 +81,12 @@ public class RestaurantScheduleController {
   //모든 생성된 음식점 스케쥴 전체 조회
   @GetMapping
   public ResponseEntity<ApiResponse<PageResponse<RestaurantScheduleResDto>>> getAllSchedule(
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "10") int size,
       @SortDefault(sort = "createdAt", direction = Direction.DESC)
       Pageable pageable) {
-    log.info("getAllRestaurants");
-
-    Pageable AllRestaurantPageable = PageRequest.of(page, size, pageable.getSort());
+    log.info("getAllRestaurantsSchedule");
 
     Page<RestaurantScheduleResDto> resPage
-        = scheduleService.AllSchedules(AllRestaurantPageable);
+        = scheduleService.AllSchedules(pageable);
     return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
   }
 
@@ -98,17 +94,13 @@ public class RestaurantScheduleController {
   //특정 음식점 스케쥴 전체 조회
   @GetMapping("/{restaurantId}")
   public ResponseEntity<ApiResponse<PageResponse<RestaurantScheduleResDto>>> readForOneRestaurantSchedule(
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "10") int size,
       @SortDefault(sort = "createdAt", direction = Direction.DESC)
       Pageable pageable,
       @PathVariable("restaurantId") UUID restaurantId) {
     log.info("getAllRestaurants");
 
-    Pageable AllRestaurantPageable = PageRequest.of(page, size, pageable.getSort());
-
     Page<RestaurantScheduleResDto> resPage
-        = scheduleService.readForOneRestaurant(restaurantId, AllRestaurantPageable);
+        = scheduleService.readForOneRestaurant(restaurantId, pageable);
     return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
   }
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
@@ -3,6 +3,7 @@ package com.bobjool.restaurant.presentation.controller.restaurantSchedule;
 import com.bobjool.common.presentation.ApiResponse;
 import com.bobjool.common.presentation.PageResponse;
 import com.bobjool.common.presentation.SuccessCode;
+import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleForCustomerResDto;
 import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantScheduleResDto;
 import com.bobjool.restaurant.application.service.restaurantSchedule.RestaurantScheduleService;
 import com.bobjool.restaurant.presentation.dto.restaurantSchedule.RestaurantScheduleCreateReqDto;
@@ -129,6 +130,18 @@ public class RestaurantScheduleController {
     Page<RestaurantScheduleResDto> response = scheduleService.createDailySchedule(2, scheduleCreateReqDto.date(),
         scheduleCreateReqDto.toServiceDto());
     return ApiResponse.success(SuccessCode.SUCCESS_INSERT, PageResponse.of(response));
+  }
+
+  @GetMapping("/user/{userId}")
+  public ResponseEntity<ApiResponse<PageResponse<RestaurantScheduleForCustomerResDto>>> readUserReserve(
+      @SortDefault(sort = "createdAt", direction = Direction.DESC)
+      Pageable pageable,
+      @PathVariable("userId") Long userId) {
+    log.info("getUserReserve");
+
+    Page<RestaurantScheduleForCustomerResDto> resPage
+        = scheduleService.readForUserReserve(userId, pageable);
+    return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(resPage));
   }
 
 }

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/controller/restaurantSchedule/RestaurantScheduleController.java
@@ -62,7 +62,7 @@ public class RestaurantScheduleController {
   public ResponseEntity<ApiResponse<RestaurantScheduleResDto>> updateSchedule(
       @Valid @RequestBody RestaurantScheduleUpdateReqDto scheduleUpdateReqDto,
       @PathVariable("ScheduleId") UUID ScheduleId) {
-    log.info("update.RestaurantUpdateReqDto={}", scheduleUpdateReqDto);
+    log.info("update.RestaurantScheduleUpdateReqDto={}", scheduleUpdateReqDto);
     RestaurantScheduleResDto response = scheduleService.updateSchedule(ScheduleId,
         scheduleUpdateReqDto.toServiceDto());
     return ApiResponse.success(SuccessCode.SUCCESS_UPDATE, response);

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/dto/restaurant/RestaurantCreateReqDto.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/dto/restaurant/RestaurantCreateReqDto.java
@@ -12,8 +12,6 @@ import java.time.LocalTime;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 
 public record RestaurantCreateReqDto (
-//      @NotNull(message = "레스토랑 ID 는 필수 입력값입니다.")
-//      UUID restaurantId,
 
       @NotNull(message = "유저 ID 는 필수 입력값입니다.")
       @Positive(message = "유저 ID 는 양수여야 합니다.")

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/dto/restaurant/RestaurantUpdateReqDto.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/dto/restaurant/RestaurantUpdateReqDto.java
@@ -12,35 +12,24 @@ public record RestaurantUpdateReqDto(
 
   RestaurantCategory restaurantCategory,
 
-//  @NotNull(message = "레스토랑 연락 번호는 필수값 입니다.")
   String restaurantPhone,
 
-//  @NotNull(message = "레스토랑 이름은 필수 입력값입니다.")
   String restaurantName,
 
-//  @NotNull(message = "레스토랑의 지역은 필수 입력값입니다.")
   RestaurantRegion restaurantRegion,
 
-//  @NotNull(message = "레스토랑 상세주소는 필수 입력값입니다.")
   String restaurantAddressDetail,
 
-//  @NotNull(message = "레스토랑 설명은 필수 입력 값입니다.")
   String restaurantDescription,
 
-//  @NotNull(message = "식당 수용 가능 인원은 필수 입력값입니다.")
-//  @Positive(message = "수용 가능 인원은 양수여야 합니다.")
   int restaurantVolume,
 
-//  @NotNull(message = "식당 예약 가능 여부는 필수 설정입니다.")
   boolean isReservation,
 
-//  @NotNull(message = "식당 대기줄 가능 여부는 필수 설정입니다.")
   boolean isQueue,
 
-//  @NotNull(message = "식당 오픈 시간은 필수 설정입니다.")
   LocalTime openTime,
 
-//  @NotNull(message = "식당 마감 시간은 필수 설정입니다.")
   LocalTime closeTime
   ) {
 

--- a/restaurant/src/main/java/com/bobjool/restaurant/presentation/dto/restaurantSchedule/RestaurantScheduleReserveReqDto.java
+++ b/restaurant/src/main/java/com/bobjool/restaurant/presentation/dto/restaurantSchedule/RestaurantScheduleReserveReqDto.java
@@ -4,26 +4,12 @@ import com.bobjool.restaurant.application.dto.restaurantSchedule.RestaurantSched
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.UUID;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record RestaurantScheduleReserveReqDto(
 
     @NotNull(message = "유저 ID 는 필수 입력값입니다.")
     Long userId,
-
-    @NotNull(message = "테이블 번호를 입력하여야 합니다.")
-    @Positive(message = "테이블 번호는 양수여야 합니다.")
-    int tableNumber,
-
-    @NotNull(message = "예약 날짜는 필수값 입니다.")
-    LocalDate date,
-
-    @NotNull(message = "예약 시간대는 필수값 입니다.")
-    LocalTime timeSlot,
 
     @NotNull(message = "테이블 예약 인원수는 필수값 입니다.")
     int currentCapacity
@@ -32,9 +18,6 @@ public record RestaurantScheduleReserveReqDto(
   public RestaurantScheduleReserveDto toServiceDto() {
     return new RestaurantScheduleReserveDto(
         userId,
-        tableNumber,
-        date,
-        timeSlot,
         currentCapacity
     );
   }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- Feat/restaurant lookup api -> dev
### 이슈
- #54
### Description
- 이전에 피드백 받은 부분 적용 후, 남은 API들 성공 케이스 위주로만 구현하였습니다.
- isQueue, isReservation 변경 기능
![image](https://github.com/user-attachments/assets/75d77b3a-bd71-474e-8318-2211a851caa8)
![image](https://github.com/user-attachments/assets/829334ec-4694-449e-b181-04ab10724fb7)

- 음식점 정보 조회 기능(역할별로 분리를 API로 해두긴 했습니다만, 추후 수정할 것 같습니다.)

이미지 첨부는 생략하겠습니다.
엔드포인트는 각각
http://localhost:19020/api/v1/restaurants/{restaurantId}
http://localhost:19020/api/v1/restaurants/customer/{restaurantId}
http://localhost:19020/api/v1/restaurants/master/{restaurantId}
입니다.

- 음식점 스케쥴 레스토랑 ID로 조회
![image](https://github.com/user-attachments/assets/57ebed49-64ea-4e78-9f16-01fd10eda2f5)

- 특정 유저의 예약 조회
![image](https://github.com/user-attachments/assets/03190a7b-ad44-4d5c-8a8b-6eb2efbc0f82)

- 음식점 스케쥴 하루치 생성
오픈시간 ~ 마감시간까지의 term을 지정하여 특정 테이블의 timeslot을 2시간별로 생성합니다.
![image](https://github.com/user-attachments/assets/4d77a41b-7d1f-4b48-ab89-e9c2d52e0519)

### To Reviewers
- 특별하게 더 필요한 API가 없다면, 조회기능 위주로 구현 또는 리팩토링 해볼 것 같습니다(QueryDSL 미사용하고 있기 때문에 성능 향상을 위해 더 공부해보고 적용할 것 같습니다.)
- 혹시 필요한 기능이 있을 것 같으면 말씀 부탁드립니다.