### PR TITLE
Feat/queue-cancel

### DIFF
--- a/common/src/main/java/com/bobjool/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/bobjool/common/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     QUEUE_EMPTY(HttpStatus.BAD_REQUEST, "대기열에 유저가 없습니다."),
     QUEUE_DATA_NOT_FOUND(HttpStatus.BAD_REQUEST, "대기번호 또는 방문인원 정보가 없습니다."),
     ALREADY_BEHIND_TARGET(HttpStatus.BAD_REQUEST, "이미 대상 사용자 뒤에 있습니다."),
+    INVALID_PROCESS_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 처리 유형입니다."),
 
     // 예약
     INVALID_GUEST_COUNT(HttpStatus.BAD_REQUEST, "예약 인원수는 양수여야 합니다."),

--- a/common/src/main/java/com/bobjool/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/bobjool/common/exception/ErrorCode.java
@@ -49,9 +49,10 @@ public enum ErrorCode {
     CANNOT_DELAY(HttpStatus.BAD_REQUEST, "대기열의 마지막 유저는 순서를 미룰 수 없습니다."),
     DELAY_LIMIT_REACHED(HttpStatus.BAD_REQUEST, "순서 미루기는 최대 2번까지 가능합니다."),
     QUEUE_EMPTY(HttpStatus.BAD_REQUEST, "대기열에 유저가 없습니다."),
-    QUEUE_DATA_NOT_FOUND(HttpStatus.BAD_REQUEST, "대기번호 또는 방문인원 정보가 없습니다."),
+    QUEUE_DATA_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자의 대기 정보를 찾을 수 없습니다."),
     ALREADY_BEHIND_TARGET(HttpStatus.BAD_REQUEST, "이미 대상 사용자 뒤에 있습니다."),
     INVALID_PROCESS_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 처리 유형입니다."),
+    USER_IS_NOT_WAITING(HttpStatus.BAD_REQUEST, "사용자는 대기중 상태가 아닙니다."),
 
     // 예약
     INVALID_GUEST_COUNT(HttpStatus.BAD_REQUEST, "예약 인원수는 양수여야 합니다."),

--- a/queue/src/main/java/com/bobjool/queue/application/dto/QueueCancelDto.java
+++ b/queue/src/main/java/com/bobjool/queue/application/dto/QueueCancelDto.java
@@ -1,0 +1,9 @@
+package com.bobjool.queue.application.dto;
+
+import java.util.UUID;
+
+public record QueueCancelDto(
+	UUID restaurantId,
+	Long userId,
+	Long targetUserId
+) { }

--- a/queue/src/main/java/com/bobjool/queue/application/dto/QueueCancelDto.java
+++ b/queue/src/main/java/com/bobjool/queue/application/dto/QueueCancelDto.java
@@ -2,8 +2,14 @@ package com.bobjool.queue.application.dto;
 
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record QueueCancelDto(
+
+	@JsonProperty("restaurantId")
 	UUID restaurantId,
+	@JsonProperty("userId")
 	Long userId,
-	Long targetUserId
+	@JsonProperty("reason")
+	String reason
 ) { }

--- a/queue/src/main/java/com/bobjool/queue/application/dto/QueueDelayDto.java
+++ b/queue/src/main/java/com/bobjool/queue/application/dto/QueueDelayDto.java
@@ -4,17 +4,14 @@ import java.util.UUID;
 
 import com.bobjool.queue.domain.enums.DiningOption;
 import com.bobjool.queue.domain.enums.QueueType;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record QueueDelayDto(
+
+	@JsonProperty("restaurantId")
 	UUID restaurantId,
+	@JsonProperty("userId")
 	Long userId,
+	@JsonProperty("targetUserId")
 	Long targetUserId
-) {
-	@Override
-	public String toString() {
-		return "{" +
-			"\"restaurantId\":\"" + restaurantId + "\"," +
-			"\"userId\":\"" + userId + "\"," +
-			"\"targetUserId\":\"" + targetUserId + "\"}";
-	}
-}
+) { }

--- a/queue/src/main/java/com/bobjool/queue/application/dto/QueueRegisterDto.java
+++ b/queue/src/main/java/com/bobjool/queue/application/dto/QueueRegisterDto.java
@@ -4,22 +4,17 @@ import java.util.UUID;
 
 import com.bobjool.queue.domain.enums.DiningOption;
 import com.bobjool.queue.domain.enums.QueueType;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record QueueRegisterDto(
+	@JsonProperty("restaurantId")
 	UUID restaurantId,
+	@JsonProperty("userId")
 	Long userId,
+	@JsonProperty("member")
 	Integer member,
+	@JsonProperty("type")
 	QueueType type,
+	@JsonProperty("diningOption")
 	DiningOption diningOption
-) {
-
-	@Override
-	public String toString() {
-		return "{" +
-			"\"restaurantId\":\"" + restaurantId + "\"," +
-			"\"userId\":\"" + userId + "\"," +
-			"\"member\":\"" + member + "\"," +
-			"\"type\":\"" + type + "\"," +
-			"\"diningOption\":\"" + diningOption + "\"}";
-	}
-}
+) { }

--- a/queue/src/main/java/com/bobjool/queue/application/service/QueueMessagePublisherService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/QueueMessagePublisherService.java
@@ -1,0 +1,46 @@
+package com.bobjool.queue.application.service;
+
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+import com.bobjool.common.exception.BobJoolException;
+import com.bobjool.common.exception.ErrorCode;
+import com.bobjool.queue.application.dto.QueueCancelDto;
+import com.bobjool.queue.application.dto.QueueDelayDto;
+import com.bobjool.queue.application.dto.QueueRegisterDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class QueueMessagePublisherService {
+
+	private final RedisQueueService redisQueueService;
+	private final ObjectMapper objectMapper;
+	private final ChannelTopic registerTopic;
+	private final ChannelTopic delayTopic;
+	private final ChannelTopic cancelTopic;
+
+	public String publishRegisterQueue(QueueRegisterDto dto) {
+		return publishMessage(registerTopic.getTopic(), dto, "대기열 요청 성공");
+	}
+
+	public String publishDelayQueue(QueueDelayDto dto) {
+		return publishMessage(delayTopic.getTopic(), dto, "대기열 내 순서 미루기 요청 성공");
+	}
+
+	public String publishCancelQueue(QueueCancelDto dto) {
+		return publishMessage(cancelTopic.getTopic(), dto, "대기열 줄서기 취소 요청 성공");
+	}
+
+	private String publishMessage(String topic, Object dto, String successMessage) {
+		try {
+			String message = objectMapper.writeValueAsString(dto);
+			redisQueueService.publishMessage(topic, message);
+			return successMessage;
+		} catch (Exception e) {
+			throw new BobJoolException(ErrorCode.QUEUE_PUBLISHING_FAILED);
+		}
+	}
+}

--- a/queue/src/main/java/com/bobjool/queue/application/service/QueueMessagePublisherService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/QueueMessagePublisherService.java
@@ -1,5 +1,6 @@
 package com.bobjool.queue.application.service;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Service;
 
@@ -16,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class QueueMessagePublisherService {
 
-	private final RedisQueueService redisQueueService;
+	private final StringRedisTemplate stringRedisTemplate;
 	private final ObjectMapper objectMapper;
 	private final ChannelTopic registerTopic;
 	private final ChannelTopic delayTopic;
@@ -37,10 +38,14 @@ public class QueueMessagePublisherService {
 	private String publishMessage(String topic, Object dto, String successMessage) {
 		try {
 			String message = objectMapper.writeValueAsString(dto);
-			redisQueueService.publishMessage(topic, message);
+			publishMessage(topic, message);
 			return successMessage;
 		} catch (Exception e) {
 			throw new BobJoolException(ErrorCode.QUEUE_PUBLISHING_FAILED);
 		}
+	}
+
+	public void publishMessage(String topic, String message) {
+		stringRedisTemplate.convertAndSend(topic, message);
 	}
 }

--- a/queue/src/main/java/com/bobjool/queue/application/service/QueueMessageSubscriber.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/QueueMessageSubscriber.java
@@ -4,6 +4,7 @@ import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Service;
 
+import com.bobjool.queue.application.dto.QueueCancelDto;
 import com.bobjool.queue.application.dto.QueueDelayDto;
 import com.bobjool.queue.application.dto.QueueRegisterDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,6 +32,16 @@ public class QueueMessageSubscriber implements MessageListener {
 				QueueDelayDto delayDto = parseMessage(messageBody, QueueDelayDto.class);
 				queueService.delayUserRank(delayDto);
 				break;
+
+			case "queue.cancel":
+				QueueCancelDto cancelDto = parseMessage(messageBody, QueueCancelDto.class);
+				queueService.cancelWaiting(cancelDto);
+				break;
+
+			// case "queue.checkin":
+			// 	QueueCheckInDto checkInDto = parseMessage(messageBody, QueueCheckInDto.class);
+			// 	queueService.checkInRestaurant(checkInDto);
+			// 	break;
 
 			default:
 				throw new IllegalArgumentException("Unknown topic: " + topic);

--- a/queue/src/main/java/com/bobjool/queue/application/service/RedisQueueService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/RedisQueueService.java
@@ -14,8 +14,10 @@ import org.springframework.stereotype.Service;
 
 import com.bobjool.common.exception.BobJoolException;
 import com.bobjool.common.exception.ErrorCode;
+import com.bobjool.queue.application.dto.QueueCancelDto;
 import com.bobjool.queue.application.dto.QueueDelayResDto;
 import com.bobjool.queue.application.dto.QueueRegisterDto;
+import com.bobjool.queue.domain.enums.QueueStatus;
 import com.bobjool.queue.domain.util.RedisKeyUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -49,6 +51,7 @@ public class RedisQueueService {
 			"type", dto.type(),
 			"dining_option", dto.diningOption(),
 			"position", position,
+			"status", QueueStatus.WAITING,
 			"delay_count", 0,
 			"created_at", System.currentTimeMillis()
 		);
@@ -57,7 +60,7 @@ public class RedisQueueService {
 		return userInfo;
 	}
 
-	public boolean isUserAlreadyWaiting(Long userId) {
+	public boolean isUserWaiting(Long userId) {
 		String userIsWaitingKey = RedisKeyUtil.getUserIsWaitingKey(userId);
 		return Boolean.TRUE.equals(redisTemplate.hasKey(userIsWaitingKey));
 	}
@@ -110,6 +113,7 @@ public class RedisQueueService {
 		double newScore = (targetScore + nextScore) / 2.0;
 		redisTemplate.opsForZSet().add(waitingListKey, String.valueOf(userId), newScore);
 		updateDelayCount(userQueueDataKey);
+		updateQueueStatus(restaurantId,userId, QueueStatus.DELAYED);
 
 		Long originalPosition = getHashValue(userQueueDataKey, "position", Long.class);
 		Integer member = getHashValue(userQueueDataKey, "member", Integer.class);
@@ -188,5 +192,39 @@ public class RedisQueueService {
 
 		Object nextUser = nextUsers.iterator().next();
 		return getUserScore(waitingListKey, Long.parseLong(nextUser.toString()));
+	}
+
+	public void cancelWaiting(QueueCancelDto dto) {
+		removeUserIsWaitingKey(dto.userId());
+		removeUserFromQueue(dto.restaurantId(),dto.userId());
+		updateQueueStatus(dto.restaurantId(), dto.userId(), QueueStatus.CANCELED);
+	}
+
+	private void removeUserFromQueue(UUID restaurantId, Long userId) {
+		String waitingListKey  = RedisKeyUtil.getWaitingListKey(restaurantId);
+		Double score = redisTemplate.opsForZSet().score(waitingListKey,String.valueOf(userId));
+		if (score != null) {
+			redisTemplate.opsForZSet().remove(waitingListKey, String.valueOf(userId));
+		} else {
+			throw new BobJoolException(ErrorCode.USER_NOT_FOUND_IN_QUEUE);
+		}
+	}
+
+	public void removeUserIsWaitingKey(Long userId) {
+		String isWaitingKey = RedisKeyUtil.getUserIsWaitingKey(userId);
+		if (isUserWaiting(userId)) {
+			redisTemplate.delete(isWaitingKey);
+		} else {
+			throw new BobJoolException(ErrorCode.USER_IS_NOT_WAITING);
+		}
+	}
+
+	private void updateQueueStatus(UUID restaurantId, Long userId, QueueStatus newStatus) {
+		String userQueueDataKey = RedisKeyUtil.getUserQueueDataKey(restaurantId, userId);
+		if (Boolean.TRUE.equals(redisTemplate.hasKey(userQueueDataKey))) {
+			redisTemplate.opsForHash().put(userQueueDataKey, "status", newStatus);
+		} else {
+			throw new BobJoolException(ErrorCode.QUEUE_DATA_NOT_FOUND);
+		}
 	}
 }

--- a/queue/src/main/java/com/bobjool/queue/application/service/RedisQueueService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/RedisQueueService.java
@@ -28,12 +28,9 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RedisQueueService {
 	private final RedisTemplate<String, Object> redisTemplate;
-	private final StringRedisTemplate stringRedisTemplate;
 
-	// 메시지 발행
-	public void publishMessage(String topic, String message) {
-		stringRedisTemplate.convertAndSend(topic, message);
-	}
+
+
 
 	// 대기 큐에 사용자 추가
 	public Map<String, Object> addUserToQueue(QueueRegisterDto dto) {

--- a/queue/src/main/java/com/bobjool/queue/infrastructure/config/redis/RedisPubSubConfig.java
+++ b/queue/src/main/java/com/bobjool/queue/infrastructure/config/redis/RedisPubSubConfig.java
@@ -35,6 +35,16 @@ public class RedisPubSubConfig {
 	}
 
 	@Bean
+	public MessageListenerAdapter cancelListenerAdapter(QueueMessageSubscriber subscriber) {
+		return new MessageListenerAdapter(subscriber, "onMessage");
+	}
+
+	@Bean
+	public MessageListenerAdapter checkInListenerAdapter(QueueMessageSubscriber subscriber) {
+		return new MessageListenerAdapter(subscriber, "onMessage");
+	}
+
+	@Bean
 	public ChannelTopic registerTopic() {
 		return new ChannelTopic("queue.register");
 	}
@@ -42,6 +52,16 @@ public class RedisPubSubConfig {
 	@Bean
 	public ChannelTopic delayTopic() {
 		return new ChannelTopic("queue.delay");
+	}
+
+	@Bean
+	public ChannelTopic cancelTopic() {
+		return new ChannelTopic("queue.cancel");
+	}
+
+	@Bean
+	public ChannelTopic checkInTopic() {
+		return new ChannelTopic("queue.checkin");
 	}
 
 }

--- a/queue/src/main/java/com/bobjool/queue/infrastructure/config/redis/RedisPubSubConfig.java
+++ b/queue/src/main/java/com/bobjool/queue/infrastructure/config/redis/RedisPubSubConfig.java
@@ -15,11 +15,13 @@ public class RedisPubSubConfig {
 	public RedisMessageListenerContainer container(
 		RedisConnectionFactory connectionFactory,
 		MessageListenerAdapter registerListenerAdapter,
-		MessageListenerAdapter delayListenerAdapter) {
+		MessageListenerAdapter delayListenerAdapter,
+		MessageListenerAdapter cancelListenerAdapter) {
 		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
 		container.addMessageListener(registerListenerAdapter, registerTopic());
 		container.addMessageListener(delayListenerAdapter, delayTopic());
+		container.addMessageListener(cancelListenerAdapter, cancelTopic());
 
 		return container;
 	}

--- a/queue/src/main/java/com/bobjool/queue/presentation/controller/QueueController.java
+++ b/queue/src/main/java/com/bobjool/queue/presentation/controller/QueueController.java
@@ -58,11 +58,11 @@ public class QueueController {
 	@DeleteMapping("/queues/{restaurantId}/{userId}")
 	public ResponseEntity<ApiResponse<String>> cancelQueue(
 		@PathVariable UUID restaurantId,
-		@PathVariable Long userId,
-		@RequestParam Long targetUserId) {
+		@PathVariable Long userId) {
 		// TODO : 롤검증 /오너라면 자신식당의 웨이팅정보변경인지 검증/ 손님이라면 내 줄서기 정보인지 확인
+		// TODO : 분기 /오너나 관리자라면 QueueCancelDto.reason : owner_or_admin / QueueCancelDto.reason : customer
 		return ApiResponse.success(SuccessCode.SUCCESS_ACCEPTED,
-			queueService.handleQueue(new QueueCancelDto(restaurantId,userId,targetUserId),"cancel"));
+			queueService.handleQueue(new QueueCancelDto(restaurantId,userId,"customer"),"cancel"));
 	}
 
 }

--- a/queue/src/main/java/com/bobjool/queue/presentation/controller/QueueController.java
+++ b/queue/src/main/java/com/bobjool/queue/presentation/controller/QueueController.java
@@ -3,6 +3,7 @@ package com.bobjool.queue.presentation.controller;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,8 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.bobjool.common.presentation.ApiResponse;
 import com.bobjool.common.presentation.SuccessCode;
+import com.bobjool.queue.application.dto.QueueCancelDto;
 import com.bobjool.queue.application.dto.QueueDelayDto;
-import com.bobjool.queue.application.dto.QueueDelayResDto;
 import com.bobjool.queue.application.dto.QueueStatusResDto;
 import com.bobjool.queue.application.service.QueueService;
 import com.bobjool.queue.presentation.dto.QueueRegisterReqDto;
@@ -33,7 +34,7 @@ public class QueueController {
 	public ResponseEntity<ApiResponse<String>> registerQueue(
 		@Valid @RequestBody QueueRegisterReqDto queueRegisterReqDto) {
 		return ApiResponse.success(SuccessCode.SUCCESS_ACCEPTED,
-			queueService.publishRegisterQueue(queueRegisterReqDto.toServiceDto()));
+			queueService.handleQueue(queueRegisterReqDto.toServiceDto(),"register"));
 	}
 
 	@GetMapping("/queues/{restaurantId}/{userId}")
@@ -51,7 +52,17 @@ public class QueueController {
 		@RequestParam Long targetUserId) {
 		// TODO : 롤검증 /오너라면 자신식당의 웨이팅정보변경인지 검증/ 손님이라면 내 줄서기 정보인지 확인
 		return ApiResponse.success(SuccessCode.SUCCESS_ACCEPTED,
-			queueService.publishDelayQueue(new QueueDelayDto(restaurantId,userId,targetUserId)));
+			queueService.handleQueue(new QueueDelayDto(restaurantId,userId,targetUserId),"delay"));
+	}
+
+	@DeleteMapping("/queues/{restaurantId}/{userId}")
+	public ResponseEntity<ApiResponse<String>> cancelQueue(
+		@PathVariable UUID restaurantId,
+		@PathVariable Long userId,
+		@RequestParam Long targetUserId) {
+		// TODO : 롤검증 /오너라면 자신식당의 웨이팅정보변경인지 검증/ 손님이라면 내 줄서기 정보인지 확인
+		return ApiResponse.success(SuccessCode.SUCCESS_ACCEPTED,
+			queueService.handleQueue(new QueueCancelDto(restaurantId,userId,targetUserId),"cancel"));
 	}
 
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/queue-cancel -> dev
### 이슈
- #55
### Description
-  isWating 키 삭제
-  식당waitingList에서 해당 유저 삭제
- 해시테이블 해당유저의 status CANCELED로 변경
1. postman
   ![image](https://github.com/user-attachments/assets/1b23f3fa-f142-4fbb-846f-ea825342f10f)

2. jmeter
    1. 취소전
   ![image](https://github.com/user-attachments/assets/d5704f9e-358e-4cc9-a7d7-8f9d126eaa7f)
    2. 세팅
![image](https://github.com/user-attachments/assets/4f1aafef-ec6e-467c-90c0-0922a010f793)
![image](https://github.com/user-attachments/assets/2edbd5ed-acb8-440f-8921-b1d22b8aa533)
![image](https://github.com/user-attachments/assets/88083d05-fc0f-48fb-92f2-a08a9f636efd)
    
    3. 결과
![image](https://github.com/user-attachments/assets/46d79b5d-be14-4966-ad13-b763996dccbc)
![image](https://github.com/user-attachments/assets/b7700aec-8e71-4938-8e8e-e1d516d8ae00)
![image](https://github.com/user-attachments/assets/e73d61fc-e124-4fc6-bc12-a6ef1f255a3d)


### To Reviewers
- 엔드 포인트 접근시 롤검증해서 취소사유에 분기처리 추가해야 함
- 입장알림 이후 10분 뒤 시스템에서 자동으로 줄서기취소 추가해야 함