### PR TITLE
Feat/queue-checkin

### DIFF
--- a/common/src/main/java/com/bobjool/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/bobjool/common/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 엔티티가 존재하지 않습니다."),
     ALREADY_DELETED(HttpStatus.CONFLICT, "이미 삭제되었습니다."),
     UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 조건입니다."),
+    UNKNOWN_TOPIC(HttpStatus.BAD_REQUEST, "알 수 없는 토픽입니다."),
+    FAILED_PARSE_MESSAGE(HttpStatus.BAD_REQUEST, "메시지를 변환에 실패하였습니다."),
 
     // 인증
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 존재하지 않습니다."),
@@ -53,6 +55,8 @@ public enum ErrorCode {
     ALREADY_BEHIND_TARGET(HttpStatus.BAD_REQUEST, "이미 대상 사용자 뒤에 있습니다."),
     INVALID_PROCESS_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 처리 유형입니다."),
     USER_IS_NOT_WAITING(HttpStatus.BAD_REQUEST, "사용자는 대기중 상태가 아닙니다."),
+    CURRENT_STATUS_NOT_FOUND(HttpStatus.BAD_REQUEST, "대상 사용자는 대기상태를 알 수 없습니다."),
+    INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "현재 상태에서는 대기상태를 변경할 수 없습니다."),
 
     // 예약
     INVALID_GUEST_COUNT(HttpStatus.BAD_REQUEST, "예약 인원수는 양수여야 합니다."),
@@ -80,4 +84,8 @@ public enum ErrorCode {
 
     private final HttpStatus httpStatus;
     private final String message;
+    // 동적으로 메시지를 생성하는 메서드
+    public String formatMessage(Object... args) {
+        return String.format(this.message, args);
+    }
 }

--- a/queue/src/main/java/com/bobjool/queue/application/dto/QueueCheckInDto.java
+++ b/queue/src/main/java/com/bobjool/queue/application/dto/QueueCheckInDto.java
@@ -1,0 +1,12 @@
+package com.bobjool.queue.application.dto;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record QueueCheckInDto(
+	@JsonProperty("restaurantId")
+	UUID restaurantId,
+	@JsonProperty("userId")
+	Long userId
+) { }

--- a/queue/src/main/java/com/bobjool/queue/application/service/QueueMessagePublisherService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/QueueMessagePublisherService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.bobjool.common.exception.BobJoolException;
 import com.bobjool.common.exception.ErrorCode;
 import com.bobjool.queue.application.dto.QueueCancelDto;
+import com.bobjool.queue.application.dto.QueueCheckInDto;
 import com.bobjool.queue.application.dto.QueueDelayDto;
 import com.bobjool.queue.application.dto.QueueRegisterDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,6 +23,7 @@ public class QueueMessagePublisherService {
 	private final ChannelTopic registerTopic;
 	private final ChannelTopic delayTopic;
 	private final ChannelTopic cancelTopic;
+	private final ChannelTopic checkInTopic;
 
 	public String publishRegisterQueue(QueueRegisterDto dto) {
 		return publishMessage(registerTopic.getTopic(), dto, "대기열 요청 성공");
@@ -33,6 +35,10 @@ public class QueueMessagePublisherService {
 
 	public String publishCancelQueue(QueueCancelDto dto) {
 		return publishMessage(cancelTopic.getTopic(), dto, "대기열 줄서기 취소 요청 성공");
+	}
+
+	public String publishCheckInQueue(QueueCheckInDto dto) {
+		return publishMessage(checkInTopic.getTopic(), dto, "대기열 식당 체크인 요청 성공");
 	}
 
 	private String publishMessage(String topic, Object dto, String successMessage) {

--- a/queue/src/main/java/com/bobjool/queue/application/service/QueueMessageSubscriber.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/QueueMessageSubscriber.java
@@ -4,6 +4,8 @@ import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Service;
 
+import com.bobjool.common.exception.BobJoolException;
+import com.bobjool.common.exception.ErrorCode;
 import com.bobjool.queue.application.dto.QueueCancelDto;
 import com.bobjool.queue.application.dto.QueueCheckInDto;
 import com.bobjool.queue.application.dto.QueueDelayDto;
@@ -45,7 +47,7 @@ public class QueueMessageSubscriber implements MessageListener {
 				break;
 
 			default:
-				throw new IllegalArgumentException("Unknown topic: " + topic);
+				throw new BobJoolException(ErrorCode.UNKNOWN_TOPIC);
 		}
 	}
 
@@ -53,7 +55,7 @@ public class QueueMessageSubscriber implements MessageListener {
 		try {
 			return objectMapper.readValue(messageBody, valueType);
 		} catch (Exception e) {
-			throw new RuntimeException("Failed to parse message body: " + messageBody, e);
+			throw new BobJoolException(ErrorCode.FAILED_PARSE_MESSAGE);
 		}
 	}
 

--- a/queue/src/main/java/com/bobjool/queue/application/service/QueueMessageSubscriber.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/QueueMessageSubscriber.java
@@ -5,6 +5,7 @@ import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Service;
 
 import com.bobjool.queue.application.dto.QueueCancelDto;
+import com.bobjool.queue.application.dto.QueueCheckInDto;
 import com.bobjool.queue.application.dto.QueueDelayDto;
 import com.bobjool.queue.application.dto.QueueRegisterDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,10 +39,10 @@ public class QueueMessageSubscriber implements MessageListener {
 				queueService.cancelWaiting(cancelDto);
 				break;
 
-			// case "queue.checkin":
-			// 	QueueCheckInDto checkInDto = parseMessage(messageBody, QueueCheckInDto.class);
-			// 	queueService.checkInRestaurant(checkInDto);
-			// 	break;
+			case "queue.checkin":
+				QueueCheckInDto checkInDto = parseMessage(messageBody, QueueCheckInDto.class);
+				queueService.checkInRestaurant(checkInDto);
+				break;
 
 			default:
 				throw new IllegalArgumentException("Unknown topic: " + topic);

--- a/queue/src/main/java/com/bobjool/queue/application/service/QueueService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/QueueService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.bobjool.common.exception.BobJoolException;
 import com.bobjool.common.exception.ErrorCode;
 import com.bobjool.queue.application.dto.QueueCancelDto;
+import com.bobjool.queue.application.dto.QueueCheckInDto;
 import com.bobjool.queue.application.dto.QueueDelayDto;
 import com.bobjool.queue.application.dto.QueueDelayResDto;
 import com.bobjool.queue.application.dto.QueueRegisterDto;
@@ -32,6 +33,7 @@ public class QueueService {
 			case "register" -> queuePublisherService.publishRegisterQueue((QueueRegisterDto)dto);
 			case "delay" -> queuePublisherService.publishDelayQueue((QueueDelayDto)dto);
 			case "cancel" -> queuePublisherService.publishCancelQueue((QueueCancelDto)dto);
+			case "checkin" -> queuePublisherService.publishCheckInQueue((QueueCheckInDto)dto);
 			default -> throw new BobJoolException(ErrorCode.INVALID_PROCESS_TYPE);
 		};
 	}
@@ -78,5 +80,8 @@ public class QueueService {
 		//TODO 1: restaurant service : 식당이름 가져오기
 		//TODO 2: auth service : 슬랙ID, 사용자명
 		//TODO 3: 카프카 메세지 발행(슬랙ID, 식당명, 사용자명, 취소사유(reason, 문장만들어서) > queue.canceled
+	}
+
+	public void checkInRestaurant(QueueCheckInDto checkInDto) {
 	}
 }

--- a/queue/src/main/java/com/bobjool/queue/application/service/QueueService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/QueueService.java
@@ -83,5 +83,6 @@ public class QueueService {
 	}
 
 	public void checkInRestaurant(QueueCheckInDto checkInDto) {
+		redisQueueService.checkInRestaurant(checkInDto);
 	}
 }

--- a/queue/src/main/java/com/bobjool/queue/application/service/RedisQueueService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/RedisQueueService.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import com.bobjool.common.exception.BobJoolException;
@@ -28,9 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RedisQueueService {
 	private final RedisTemplate<String, Object> redisTemplate;
-
-
-
 
 	// 대기 큐에 사용자 추가
 	public Map<String, Object> addUserToQueue(QueueRegisterDto dto) {

--- a/queue/src/main/java/com/bobjool/queue/application/service/RedisQueueService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/RedisQueueService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import com.bobjool.common.exception.BobJoolException;
 import com.bobjool.common.exception.ErrorCode;
 import com.bobjool.queue.application.dto.QueueCancelDto;
+import com.bobjool.queue.application.dto.QueueCheckInDto;
 import com.bobjool.queue.application.dto.QueueDelayResDto;
 import com.bobjool.queue.application.dto.QueueRegisterDto;
 import com.bobjool.queue.domain.enums.QueueStatus;
@@ -219,5 +220,11 @@ public class RedisQueueService {
 		} else {
 			throw new BobJoolException(ErrorCode.QUEUE_DATA_NOT_FOUND);
 		}
+	}
+
+	public void checkInRestaurant(QueueCheckInDto dto) {
+		removeUserIsWaitingKey(dto.userId());
+		removeUserFromQueue(dto.restaurantId(),dto.userId());
+		updateQueueStatus(dto.restaurantId(), dto.userId(), QueueStatus.CHECK_IN);
 	}
 }

--- a/queue/src/main/java/com/bobjool/queue/infrastructure/config/redis/RedisPubSubConfig.java
+++ b/queue/src/main/java/com/bobjool/queue/infrastructure/config/redis/RedisPubSubConfig.java
@@ -16,12 +16,14 @@ public class RedisPubSubConfig {
 		RedisConnectionFactory connectionFactory,
 		MessageListenerAdapter registerListenerAdapter,
 		MessageListenerAdapter delayListenerAdapter,
-		MessageListenerAdapter cancelListenerAdapter) {
+		MessageListenerAdapter cancelListenerAdapter,
+		MessageListenerAdapter checkInListenerAdapter) {
 		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
 		container.addMessageListener(registerListenerAdapter, registerTopic());
 		container.addMessageListener(delayListenerAdapter, delayTopic());
 		container.addMessageListener(cancelListenerAdapter, cancelTopic());
+		container.addMessageListener(checkInListenerAdapter, cancelTopic());
 
 		return container;
 	}

--- a/queue/src/main/java/com/bobjool/queue/infrastructure/config/redis/RedisPubSubConfig.java
+++ b/queue/src/main/java/com/bobjool/queue/infrastructure/config/redis/RedisPubSubConfig.java
@@ -23,7 +23,7 @@ public class RedisPubSubConfig {
 		container.addMessageListener(registerListenerAdapter, registerTopic());
 		container.addMessageListener(delayListenerAdapter, delayTopic());
 		container.addMessageListener(cancelListenerAdapter, cancelTopic());
-		container.addMessageListener(checkInListenerAdapter, cancelTopic());
+		container.addMessageListener(checkInListenerAdapter, checkInTopic());
 
 		return container;
 	}

--- a/queue/src/main/java/com/bobjool/queue/presentation/controller/QueueController.java
+++ b/queue/src/main/java/com/bobjool/queue/presentation/controller/QueueController.java
@@ -15,9 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.bobjool.common.presentation.ApiResponse;
 import com.bobjool.common.presentation.SuccessCode;
 import com.bobjool.queue.application.dto.QueueCancelDto;
+import com.bobjool.queue.application.dto.QueueCheckInDto;
 import com.bobjool.queue.application.dto.QueueDelayDto;
 import com.bobjool.queue.application.dto.QueueStatusResDto;
 import com.bobjool.queue.application.service.QueueService;
+import com.bobjool.queue.application.service.RedisQueueService;
 import com.bobjool.queue.presentation.dto.QueueRegisterReqDto;
 
 import jakarta.validation.Valid;
@@ -29,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class QueueController {
 
 	private final QueueService queueService;
+	private final RedisQueueService redisService;
 
 	@PostMapping("/queues")
 	public ResponseEntity<ApiResponse<String>> registerQueue(
@@ -59,10 +62,22 @@ public class QueueController {
 	public ResponseEntity<ApiResponse<String>> cancelQueue(
 		@PathVariable UUID restaurantId,
 		@PathVariable Long userId) {
+		redisService.isUserWaiting(userId);
 		// TODO : 롤검증 /오너라면 자신식당의 웨이팅정보변경인지 검증/ 손님이라면 내 줄서기 정보인지 확인
 		// TODO : 분기 /오너나 관리자라면 QueueCancelDto.reason : owner_or_admin / QueueCancelDto.reason : customer
 		return ApiResponse.success(SuccessCode.SUCCESS_ACCEPTED,
 			queueService.handleQueue(new QueueCancelDto(restaurantId,userId,"customer"),"cancel"));
+	}
+
+	@PostMapping("/queues/{restaurantId}/{userId}/check-in")
+	public ResponseEntity<ApiResponse<String>> checkInRestaurant(
+		@PathVariable UUID restaurantId,
+		@PathVariable Long userId) {
+		redisService.isUserWaiting(userId);
+		// TODO : 롤검증 /오너
+		// TODO 자신식당인지 검증
+		return ApiResponse.success(SuccessCode.SUCCESS_ACCEPTED,
+			queueService.handleQueue(new QueueCheckInDto(restaurantId,userId),"checkin"));
 	}
 
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/queue-checkin -> dev
### 이슈
- #65 
### Description
- isWaiting 키 삭제
- 식당 waitingList 에서 해당유저 삭제
- 해시테이블 해당유저 status CHECK_IN으로 변경
- postman
![image](https://github.com/user-attachments/assets/b409354c-6cd0-4b07-80dd-93e18e0e5349)
- 체크인 전 데이터
![image](https://github.com/user-attachments/assets/608e0965-2272-4091-9148-f7f78b654440)
- 체크인 후 데이터
![image](https://github.com/user-attachments/assets/f78d6fbe-d751-4e4c-b30d-496eb9272e3d)

### To Reviewers
- 질문1. 줄서기 취소 : 요청만 받아들이고 202로 응답하다보니까 사용자가 줄을 선 상태가 아닐 때에도 응답한 다음에 내부적으로 exception이 일어나서.. 
![image](https://github.com/user-attachments/assets/1465a626-8423-4095-bae2-20ed6e2966a5)
메시지 퍼블리시 전에 검증을 해야하는게 아닐까요?
- 질문2 : 해시테이블 status만 변경? vs cancel이나 checkin 시에는 삭제  