### PR TITLE
Feat/notification - 알림 히스토리 API #102

### DIFF
--- a/notification/http/notification.http
+++ b/notification/http/notification.http
@@ -1,0 +1,41 @@
+### 히스토리 검색(조건 없음)
+GET localhost:19050/api/v1/notifications
+
+### 히스토리 검색(한개의 필드)
+GET localhost:19050/api/v1/notifications?action=REGISTERED
+
+### 히스토리 검색(여러개 필드)
+GET localhost:19050/api/v1/notifications?category=QUEUE&channel=SLACK
+
+### 히스토리 검색(해당 날짜만)
+GET localhost:19050/api/v1/notifications?date=2025-01-07
+
+### 히스토리 검색(메시지 내용 부분 검색)
+GET localhost:19050/api/v1/notifications?message=인원
+
+### 히스토리 검색(전체 필드)
+GET localhost:19050/api/v1/notifications?
+    userId=-2&
+    category=QUEUE&
+    action=REGISTERED&
+    channel=SLACK&
+    message=철수님&
+    date=2025-01-09
+
+### 히스토리 검색(페이징)
+GET localhost:19050/api/v1/notifications?
+    page=0&
+    size=1&
+    sort=createdAt,desc
+
+### 히스토리 검색(전체 조건)
+GET localhost:19050/api/v1/notifications?
+    userId=-2&
+    category=QUEUE&
+    action=REGISTERED&
+    channel=SLACK&
+    message=철수님&
+    date=2025-01-09&
+    page=0&
+    size=1&
+    sort=createdAt,desc

--- a/notification/http/template.http
+++ b/notification/http/template.http
@@ -1,4 +1,4 @@
-### 템플릿 생성
+### 템플릿 생성(웨이팅 등록 알림)
 POST localhost:19050/api/v1/notifications/templates
 Content-Type: application/json
 
@@ -9,6 +9,19 @@ Content-Type: application/json
   "title": "밥줄에 웨이팅이 등록됐습니다!",
   "template" : "${user_name}님, ${restaurant_name} 웨이팅이 등록되었습니다!\n\n웨이팅 정보\n인원: ${member}명\n순서: ${rank}번째\n번호: ${position}"
 }
+
+### 템플릿 생성(예약 완료 알림)
+POST localhost:19050/api/v1/notifications/templates
+Content-Type: application/json
+
+{
+  "service_type": "QUEUE",
+  "channel": "SLACK",
+  "type": "REGISTERED",
+  "title": "{restaurant_name} 예약이 완료됐습니다!",
+  "template" : "${user_name}님! {restaurant_name} 예약 내역을 확인해주세요.\n\n날짜: ${date}\n시간: ${time}\n인원: ${count}명\n전화번호: ${restaurant_number}\n\n* 예약해주셔서 감사합니다.\n* 예약시간 준수 부탁드리며, 예약시간 10분전까지 입장 완료 부탁드립니다."
+}
+
 
 ### 템플릿 조회
 GET localhost:19050/api/v1/notifications/templates

--- a/notification/src/main/java/com/bobjool/notification/application/dto/NotificationHistoryDto.java
+++ b/notification/src/main/java/com/bobjool/notification/application/dto/NotificationHistoryDto.java
@@ -1,0 +1,34 @@
+package com.bobjool.notification.application.dto;
+
+import com.bobjool.notification.domain.entity.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record NotificationHistoryDto(
+        UUID id,
+        Long userId,
+        BobjoolServiceType category,
+        NotificationType action,
+        NotificationChannel channel,
+        String contact,
+        String message,
+        UUID templateId,
+        String templateData,
+        LocalDateTime createdAt
+) {
+    public static NotificationHistoryDto from(Notification notification, Template template) {
+        return new NotificationHistoryDto(
+                notification.getId(),
+                notification.getUserId(),
+                template.getServiceType(),
+                template.getType(),
+                template.getChannel(),
+                notification.getContact(),
+                notification.getMessage(),
+                template.getId(),
+                notification.getJsonData(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/notification/src/main/java/com/bobjool/notification/application/dto/NotificationSearchDto.java
+++ b/notification/src/main/java/com/bobjool/notification/application/dto/NotificationSearchDto.java
@@ -1,0 +1,17 @@
+package com.bobjool.notification.application.dto;
+
+import com.bobjool.notification.domain.entity.BobjoolServiceType;
+import com.bobjool.notification.domain.entity.NotificationChannel;
+import com.bobjool.notification.domain.entity.NotificationType;
+
+import java.time.LocalDate;
+
+public record NotificationSearchDto(
+        Long userId,
+        String message,
+        LocalDate date,
+        BobjoolServiceType category,
+        NotificationType action,
+        NotificationChannel channel
+) {
+}

--- a/notification/src/main/java/com/bobjool/notification/application/service/NotificationService.java
+++ b/notification/src/main/java/com/bobjool/notification/application/service/NotificationService.java
@@ -2,11 +2,15 @@ package com.bobjool.notification.application.service;
 
 
 import com.bobjool.notification.application.dto.NotificationDto;
+import com.bobjool.notification.application.dto.NotificationHistoryDto;
+import com.bobjool.notification.application.dto.NotificationSearchDto;
 import com.bobjool.notification.domain.entity.Notification;
 import com.bobjool.notification.domain.entity.Template;
 import com.bobjool.notification.domain.repository.NotificationRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -17,6 +21,23 @@ public class NotificationService {
     private final SlackService slackService;
     private final NotificationRepository notificationRepository;
     private final TemplateService templateService;
+
+    public Page<NotificationHistoryDto> searchNotification(NotificationSearchDto searchDto, Pageable pageable) {
+
+        Page<Notification> notificationPage = notificationRepository.search(
+                searchDto.userId(),
+                searchDto.message(),
+                searchDto.date(),
+                searchDto.category(),
+                searchDto.action(),
+                searchDto.channel(),
+                pageable
+        );
+
+        return notificationPage.map(notification ->
+                NotificationHistoryDto.from(notification, notification.getTemplateId())
+        );
+    }
 
     @Transactional
     public void postNotification(NotificationDto dto) {

--- a/notification/src/main/java/com/bobjool/notification/domain/repository/NotificationRepository.java
+++ b/notification/src/main/java/com/bobjool/notification/domain/repository/NotificationRepository.java
@@ -1,10 +1,27 @@
 package com.bobjool.notification.domain.repository;
 
+import com.bobjool.notification.domain.entity.BobjoolServiceType;
 import com.bobjool.notification.domain.entity.Notification;
+import com.bobjool.notification.domain.entity.NotificationChannel;
+import com.bobjool.notification.domain.entity.NotificationType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
 
 /**
  * 도메인 관점 인터페이스
  */
 public interface NotificationRepository {
     Notification save(Notification notification);
+
+    Page<Notification> search(
+            Long userId,
+            String message,
+            LocalDate date,
+            BobjoolServiceType category,
+            NotificationType action,
+            NotificationChannel channel,
+            Pageable pageable
+    );
 }

--- a/notification/src/main/java/com/bobjool/notification/infrastructure/repository/NotificationRepositoryCustom.java
+++ b/notification/src/main/java/com/bobjool/notification/infrastructure/repository/NotificationRepositoryCustom.java
@@ -1,7 +1,25 @@
 package com.bobjool.notification.infrastructure.repository;
 
+import com.bobjool.notification.domain.entity.BobjoolServiceType;
+import com.bobjool.notification.domain.entity.Notification;
+import com.bobjool.notification.domain.entity.NotificationChannel;
+import com.bobjool.notification.domain.entity.NotificationType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+
 /**
  * QueryDSL 인터페이스
  */
 public interface NotificationRepositoryCustom {
+    Page<Notification> search(
+            Long userId,
+            String message,
+            LocalDate date,
+            BobjoolServiceType category,
+            NotificationType action,
+            NotificationChannel channel,
+            Pageable pageable
+    );
 }

--- a/notification/src/main/java/com/bobjool/notification/infrastructure/repository/NotificationRepositoryCustomImpl.java
+++ b/notification/src/main/java/com/bobjool/notification/infrastructure/repository/NotificationRepositoryCustomImpl.java
@@ -1,7 +1,26 @@
 package com.bobjool.notification.infrastructure.repository;
 
+import com.bobjool.common.exception.BobJoolException;
+import com.bobjool.common.exception.ErrorCode;
+import com.bobjool.notification.domain.entity.BobjoolServiceType;
+import com.bobjool.notification.domain.entity.Notification;
+import com.bobjool.notification.domain.entity.NotificationChannel;
+import com.bobjool.notification.domain.entity.NotificationType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.bobjool.notification.domain.entity.QNotification.notification;
+import static com.bobjool.notification.domain.entity.QTemplate.template1;
 
 /**
  * QueryDSL 구현체
@@ -9,4 +28,116 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Notification> search(
+            Long userId,
+            String message,
+            LocalDate date,
+            BobjoolServiceType category,
+            NotificationType action,
+            NotificationChannel channel,
+            Pageable pageable
+    ) {
+        BooleanBuilder builder = this.toBooleanBuilder(
+                userId,
+                message,
+                date,
+                category,
+                action,
+                channel
+        );
+        List<Notification> contents = queryFactory.selectFrom(notification)
+                .innerJoin(notification.templateId, template1)
+                .where(builder)
+                .orderBy(getOrderSpecifiers(pageable))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = queryFactory.select(notification.count())
+                .from(notification)
+                .innerJoin(notification.templateId, template1)
+                .where(builder)
+                .fetchOne();
+
+        return PageableExecutionUtils.getPage(
+                contents,
+                pageable,
+                () -> totalCount
+        );
+    }
+
+    private BooleanBuilder toBooleanBuilder(
+            Long userId,
+            String message,
+            LocalDate date,
+            BobjoolServiceType category,
+            NotificationType action,
+            NotificationChannel channel
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(eqDeletedAtIsNull());
+        if (userId != null) builder.and(eqUserId(userId));
+        if (message != null) builder.and(eqMessage(message));
+        if (date != null) builder.and(eqDate(date));
+        if (category != null) builder.and(eqServiceType(category));
+        if (action != null) builder.and(eqType(action));
+        if (channel != null) builder.and(eqChannel(channel));
+
+        return builder;
+    }
+
+    private BooleanExpression eqDeletedAtIsNull() {
+        return notification.deletedAt.isNull();
+    }
+
+    private BooleanExpression eqUserId(Long userId) {
+        return userId != null ? notification.userId.eq(userId) : null;
+    }
+
+    private BooleanExpression eqMessage(String message) {
+        return !message.isBlank() ? notification.message.containsIgnoreCase(message) : null;
+    }
+
+    private BooleanExpression eqDate(LocalDate date) {
+        return date != null ? notification.createdAt.between(
+                date.atStartOfDay(),
+                date.plusDays(1).atStartOfDay()
+        ) : null;
+    }
+
+    private BooleanExpression eqServiceType(BobjoolServiceType category) {
+        return category != null ? template1.serviceType.eq(category) : null;
+    }
+
+    private BooleanExpression eqType(NotificationType type) {
+        return type != null ? template1.type.eq(type) : null;
+    }
+
+    private BooleanExpression eqChannel(NotificationChannel channel) {
+        return channel != null ? template1.channel.eq(channel) : null;
+    }
+
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    ComparableExpressionBase<?> sortPath = getSortPath(order.getProperty());
+                    return new OrderSpecifier<>(
+                            order.isAscending()
+                                    ? com.querydsl.core.types.Order.ASC
+                                    : com.querydsl.core.types.Order.DESC,
+                            sortPath);
+                })
+                .toArray(OrderSpecifier[]::new);
+    }
+
+    private ComparableExpressionBase<?> getSortPath(String property) {
+        return switch (property) {
+            case "createdAt" -> notification.createdAt;
+            case "userId" -> notification.userId;
+            case "status" -> notification.status;
+            default -> throw new BobJoolException(ErrorCode.UNSUPPORTED_SORT_TYPE);
+        };
+    }
 }

--- a/notification/src/main/java/com/bobjool/notification/presentation/controller/NotificationController.java
+++ b/notification/src/main/java/com/bobjool/notification/presentation/controller/NotificationController.java
@@ -1,13 +1,19 @@
 package com.bobjool.notification.presentation.controller;
 
+import com.bobjool.common.presentation.ApiResponse;
+import com.bobjool.common.presentation.PageResponse;
+import com.bobjool.common.presentation.SuccessCode;
 import com.bobjool.notification.application.service.NotificationService;
 import com.bobjool.notification.presentation.request.NotificationReqDto;
+import com.bobjool.notification.presentation.request.NotificationSearchReqDto;
+import com.bobjool.notification.presentation.response.NotificationSearchResDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -21,5 +27,17 @@ public class NotificationController {
         notificationService.postNotification(reqDto.toServiceDto());
     }
 
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<NotificationSearchResDto>>> searchNotifications(
+            @ModelAttribute NotificationSearchReqDto reqDto,
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
+    ) {
+        Page<NotificationSearchResDto> response = notificationService.searchNotification(
+                        NotificationSearchReqDto.toServiceDto(reqDto), pageable
+                )
+                .map(NotificationSearchResDto::from);
+
+        return ApiResponse.success(SuccessCode.SUCCESS, PageResponse.of(response));
+    }
 
 }

--- a/notification/src/main/java/com/bobjool/notification/presentation/request/NotificationSearchReqDto.java
+++ b/notification/src/main/java/com/bobjool/notification/presentation/request/NotificationSearchReqDto.java
@@ -1,0 +1,28 @@
+package com.bobjool.notification.presentation.request;
+
+import com.bobjool.notification.application.dto.NotificationSearchDto;
+import com.bobjool.notification.domain.entity.BobjoolServiceType;
+import com.bobjool.notification.domain.entity.NotificationChannel;
+import com.bobjool.notification.domain.entity.NotificationType;
+
+import java.time.LocalDate;
+
+public record NotificationSearchReqDto(
+        Long userId,
+        String message,
+        LocalDate date,
+        String category,
+        String action,
+        String channel
+) {
+    public static NotificationSearchDto toServiceDto(NotificationSearchReqDto searchDto) {
+        return new NotificationSearchDto(
+                searchDto.userId(),
+                searchDto.message(),
+                searchDto.date(),
+                searchDto.category() != null ? BobjoolServiceType.of(searchDto.category()) : null,
+                searchDto.action() != null ? NotificationType.of(searchDto.action()) : null,
+                searchDto.channel() != null ? NotificationChannel.of(searchDto.channel()) : null
+        );
+    }
+}

--- a/notification/src/main/java/com/bobjool/notification/presentation/response/NotificationSearchResDto.java
+++ b/notification/src/main/java/com/bobjool/notification/presentation/response/NotificationSearchResDto.java
@@ -1,0 +1,32 @@
+package com.bobjool.notification.presentation.response;
+
+import com.bobjool.notification.application.dto.NotificationHistoryDto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record NotificationSearchResDto(
+        Long userId,
+        String category,
+        String action,
+        String channel,
+        String contact,
+        String message,
+        UUID templateId,
+        String templateData,
+        LocalDateTime createdAt
+) {
+    public static NotificationSearchResDto from(NotificationHistoryDto historyDto) {
+        return new NotificationSearchResDto(
+                historyDto.userId(),
+                historyDto.category().name(),
+                historyDto.action().name(),
+                historyDto.channel().name(),
+                historyDto.contact(),
+                historyDto.message(),
+                historyDto.templateId(),
+                historyDto.templateData(),
+                historyDto.createdAt()
+        );
+    }
+}

--- a/notification/src/main/java/com/bobjool/notification/presentation/response/NotificationSearchResDto.java
+++ b/notification/src/main/java/com/bobjool/notification/presentation/response/NotificationSearchResDto.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record NotificationSearchResDto(
+        UUID id,
         Long userId,
         String category,
         String action,
@@ -18,6 +19,7 @@ public record NotificationSearchResDto(
 ) {
     public static NotificationSearchResDto from(NotificationHistoryDto historyDto) {
         return new NotificationSearchResDto(
+                historyDto.id(),
                 historyDto.userId(),
                 historyDto.category().name(),
                 historyDto.action().name(),

--- a/notification/src/main/resources/application-dev.yml
+++ b/notification/src/main/resources/application-dev.yml
@@ -32,14 +32,14 @@ spring:
 notification:
   template-mapping:
     queue:
-      registered: e1abddb1-c899-404d-8b15-5d32a6463139
+      registered: 857ba751-13ac-45aa-956e-048368c7f5b9
       delayed: b2e9aebb-001d-462b-8012-854ee6aca1f5
       remind: b2e9aebb-001d-462b-8012-854ee6aca1f5
       alerted: b2e9aebb-001d-462b-8012-854ee6aca1f5
       rush: b2e9aebb-001d-462b-8012-854ee6aca1f5
       canceled: b2e9aebb-001d-462b-8012-854ee6aca1f5
     reservation:
-      completed: b2e9aebb-001d-462b-8012-854ee6aca1f5
+      completed: 24397246-5bfe-4b62-a6ca-bfd2e42d4ee3
       failed: b2e9aebb-001d-462b-8012-854ee6aca1f5
       refund: b2e9aebb-001d-462b-8012-854ee6aca1f5
       remind: b2e9aebb-001d-462b-8012-854ee6aca1f5


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/notification-search -> dev
### 이슈
- #102
### Description

![image](https://github.com/user-attachments/assets/a0e1481f-714c-4b07-bdfc-af7543668cbd)

- 알림 히스토리를 동적으로 검색할 수 있는 기능입니다.
![image](https://github.com/user-attachments/assets/0f72851a-6580-40e1-b6e4-b3e42c14aae9)


### To Reviewers
- QueryDSL을 이번 방식으로는 처음 적용하는 것이라 자유롭게 의견 주시면 감사하겠습니다!
- `.http`파일에 테스트 했던 조건이 나열되어있습니다.