### PR TITLE
[Auth] feat/auth-dev  #101

### DIFF
--- a/auth/src/main/java/com/bobjool/AuthApplication.java
+++ b/auth/src/main/java/com/bobjool/AuthApplication.java
@@ -2,7 +2,9 @@ package com.bobjool;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class AuthApplication {
     public static void main(String[] args) {

--- a/auth/src/main/java/com/bobjool/application/client/NotificationClient.java
+++ b/auth/src/main/java/com/bobjool/application/client/NotificationClient.java
@@ -1,0 +1,11 @@
+package com.bobjool.application.client;
+
+import com.bobjool.common.presentation.ApiResponse;
+
+import java.util.Map;
+
+public interface NotificationClient {
+    ApiResponse<Map<String, String>> findSlackIdByEmail(
+            String email
+    );
+}

--- a/auth/src/main/java/com/bobjool/application/dto/SignInResDto.java
+++ b/auth/src/main/java/com/bobjool/application/dto/SignInResDto.java
@@ -1,10 +1,10 @@
-package com.bobjool.presentation.dto.response;
+package com.bobjool.application.dto;
 
 public record SignInResDto(
         String accessToken
 ) {
 
-    public static SignInResDto of(String accessToken) {
+    public static SignInResDto from(String accessToken) {
         return new SignInResDto(accessToken);
     }
 }

--- a/auth/src/main/java/com/bobjool/application/dto/UpdateUserResDto.java
+++ b/auth/src/main/java/com/bobjool/application/dto/UpdateUserResDto.java
@@ -1,4 +1,4 @@
-package com.bobjool.presentation.dto.response;
+package com.bobjool.application.dto;
 
 import com.bobjool.domain.entity.User;
 
@@ -7,7 +7,7 @@ public record UpdateUserResDto (
         String slackId,
         String phoneNumber
 ) {
-    public static UpdateUserResDto of(User user) {
+    public static UpdateUserResDto from(User user) {
         return new UpdateUserResDto(
                 user.getSlackEmail(),
                 user.getSlackId(),

--- a/auth/src/main/java/com/bobjool/application/dto/UserContactResDto.java
+++ b/auth/src/main/java/com/bobjool/application/dto/UserContactResDto.java
@@ -1,0 +1,19 @@
+package com.bobjool.application.dto;
+
+import com.bobjool.domain.entity.User;
+
+public record UserContactResDto(
+        String name,
+        String email,
+        String slackId,
+        String phoneNumber
+) {
+    public static UserContactResDto from(User user) {
+        return new UserContactResDto(
+                user.getName(),
+                user.getEmail(),
+                user.getSlackId(),
+                user.getPhoneNumber()
+        );
+    }
+}

--- a/auth/src/main/java/com/bobjool/application/dto/UserResDto.java
+++ b/auth/src/main/java/com/bobjool/application/dto/UserResDto.java
@@ -1,4 +1,4 @@
-package com.bobjool.presentation.dto.response;
+package com.bobjool.application.dto;
 
 import com.bobjool.domain.entity.User;
 import com.bobjool.domain.entity.UserRole;
@@ -18,7 +18,7 @@ public record UserResDto(
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-    public static UserResDto of(User user) {
+    public static UserResDto from(User user) {
         return new UserResDto(
                 user.getId(),
                 user.getUsername(),

--- a/auth/src/main/java/com/bobjool/application/interfaces/JwtUtil.java
+++ b/auth/src/main/java/com/bobjool/application/interfaces/JwtUtil.java
@@ -1,7 +1,6 @@
 package com.bobjool.application.interfaces;
 
 import com.bobjool.domain.entity.User;
-import com.bobjool.presentation.dto.response.SignInResDto;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 

--- a/auth/src/main/java/com/bobjool/application/service/AuthService.java
+++ b/auth/src/main/java/com/bobjool/application/service/AuthService.java
@@ -3,6 +3,7 @@ package com.bobjool.application.service;
 import com.bobjool.application.client.NotificationClient;
 import com.bobjool.application.dto.SignInDto;
 import com.bobjool.application.dto.SignUpDto;
+import com.bobjool.application.dto.UserResDto;
 import com.bobjool.application.interfaces.JwtUtil;
 import com.bobjool.common.exception.*;
 import com.bobjool.domain.entity.User;
@@ -106,5 +107,24 @@ public class AuthService {
         boolean isAccessToken = "access".equals(tokenType);
 
         jwtBlacklistService.addToBlacklist(token, expiration, isAccessToken);
+    }
+
+    @Transactional
+    public UserResDto updateUserApproval(Long id, Boolean approved) {
+
+        User user = findUserById(id);
+
+        if (!user.isOwner()) {
+            throw new BobJoolException(ErrorCode.MISSING_OWNER_ROLE);
+        }
+
+        user.updateUserApproval(approved);
+
+        return UserResDto.from(user);
+    }
+
+    private User findUserById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new BobJoolException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/auth/src/main/java/com/bobjool/application/service/AuthService.java
+++ b/auth/src/main/java/com/bobjool/application/service/AuthService.java
@@ -1,12 +1,14 @@
 package com.bobjool.application.service;
 
+import com.bobjool.application.client.NotificationClient;
 import com.bobjool.application.dto.SignInDto;
 import com.bobjool.application.dto.SignUpDto;
 import com.bobjool.application.interfaces.JwtUtil;
 import com.bobjool.common.exception.*;
 import com.bobjool.domain.entity.User;
 import com.bobjool.domain.repository.UserRepository;
-import com.bobjool.presentation.dto.response.SignInResDto;
+import com.bobjool.application.dto.SignInResDto;
+import feign.FeignException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +30,7 @@ public class AuthService {
     private final JwtBlacklistService jwtBlacklistService;
     private final PasswordEncoder passwordEncoder;
     private final ValidationService validationService;
+    private final NotificationClient notificationClient;
 
     public SignInResDto signIn(SignInDto request) {
 
@@ -47,7 +50,7 @@ public class AuthService {
 
         String token = jwtUtil.createAccessToken(user);
 
-        return SignInResDto.of(token);
+        return SignInResDto.from(token);
     }
 
     @Transactional
@@ -59,13 +62,16 @@ public class AuthService {
         validationService.validateDuplicateEmail(request.email());
         validationService.validateDuplicatePhoneNumber(request.phoneNumber());
 
+        String slackEmail = request.slackEmail();
         String slackId = "";
 
-        if (request.slackEmail() != null && !request.slackEmail().isEmpty()) {
-            // TODO 슬랙 이메일로 슬랙 ID를 불러오는 API 호출 예정
-            slackId = "api로 호출한 slack_id";
+        if (slackEmail != null && !slackEmail.isEmpty()) {
+            try {
+                slackId = notificationClient.findSlackIdByEmail(slackEmail).data().get("slack_id");
+            } catch (FeignException e) {
+                throw new BobJoolException(ErrorCode.INVALID_SLACK_EMAIL);
+            }
         }
-
 
         User user = User.create(
                 request.username(),

--- a/auth/src/main/java/com/bobjool/application/service/UserService.java
+++ b/auth/src/main/java/com/bobjool/application/service/UserService.java
@@ -81,33 +81,19 @@ public class UserService {
     }
 
     @Transactional
-    public UserResDto updateUserApproval(Long id, Boolean approved) {
-
-        User user = findUserById(id);
-
-        if (!user.isOwner()) {
-            throw new BobJoolException(ErrorCode.MISSING_OWNER_ROLE);
-        }
-
-        user.updateUserApproval(approved);
-
-        return UserResDto.from(user);
-    }
-
-    @Transactional
     public void deleteUser(Long id) {
         User user = findUserById(id);
         user.delete(id);
-    }
-
-    private User findUserById(Long id) {
-        return userRepository.findById(id)
-                .orElseThrow(() -> new BobJoolException(ErrorCode.USER_NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
     public UserContactResDto getContact(Long id) {
         User user = findUserById(id);
         return UserContactResDto.from(user);
+    }
+
+    private User findUserById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new BobJoolException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/auth/src/main/java/com/bobjool/application/service/UserService.java
+++ b/auth/src/main/java/com/bobjool/application/service/UserService.java
@@ -1,13 +1,15 @@
 package com.bobjool.application.service;
 
+import com.bobjool.application.client.NotificationClient;
 import com.bobjool.application.dto.UpdateUserDto;
+import com.bobjool.application.dto.UserContactResDto;
+import com.bobjool.application.dto.UserResDto;
 import com.bobjool.common.exception.BobJoolException;
 import com.bobjool.common.exception.ErrorCode;
 import com.bobjool.domain.entity.User;
-import com.bobjool.domain.entity.UserRole;
 import com.bobjool.domain.repository.UserRepository;
-import com.bobjool.presentation.dto.response.UpdateUserResDto;
-import com.bobjool.presentation.dto.response.UserResDto;
+import com.bobjool.application.dto.UpdateUserResDto;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,13 +23,15 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ValidationService validationService;
+    private final NotificationClient notificationClient;
 
     @Transactional(readOnly = true)
     public UserResDto getUserById(Long id) {
 
         User user = findUserById(id);
 
-        return UserResDto.of(user);
+        return UserResDto.from(user);
     }
 
     @Transactional(readOnly = true)
@@ -35,15 +39,19 @@ public class UserService {
 
         Page<User> paymentPage = userRepository.search(pageable);
 
-        return paymentPage.map(UserResDto::of);
+        return paymentPage.map(UserResDto::from);
     }
 
     @Transactional
     public UpdateUserResDto updateUser(UpdateUserDto request, Long id) {
 
+        validationService.validateDuplicateSlackEmail(request.slackEmail());
+        validationService.validateDuplicatePhoneNumber(request.phoneNumber());
+
         User user = findUserById(id);
 
         String newPassword = null;
+
         if (request.currentPassword() != null && request.newPassword() != null) {
             if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
                 throw new BobJoolException(ErrorCode.INVALID_PASSWORD);
@@ -51,10 +59,15 @@ public class UserService {
             newPassword = passwordEncoder.encode(request.newPassword());
         }
 
+        String slackEmail = request.slackEmail();
         String slackId = null;
-        if (request.slackEmail() != null && !request.slackEmail().isEmpty()) {
-            // TODO: slack email로 slack id 가져오는 api 호출 후 같이 업데이트 예정
-            slackId = "";
+
+        if (slackEmail != null && !slackEmail.isEmpty()) {
+            try {
+                slackId = notificationClient.findSlackIdByEmail(slackEmail).data().get("slack_id");
+            } catch (FeignException e) {
+                throw new BobJoolException(ErrorCode.INVALID_SLACK_EMAIL);
+            }
         }
 
         user.update(
@@ -64,7 +77,7 @@ public class UserService {
                 request.phoneNumber()
         );
 
-        return UpdateUserResDto.of(user);
+        return UpdateUserResDto.from(user);
     }
 
     @Transactional
@@ -78,7 +91,7 @@ public class UserService {
 
         user.updateUserApproval(approved);
 
-        return UserResDto.of(user);
+        return UserResDto.from(user);
     }
 
     @Transactional
@@ -90,5 +103,11 @@ public class UserService {
     private User findUserById(Long id) {
         return userRepository.findById(id)
                 .orElseThrow(() -> new BobJoolException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public UserContactResDto getContact(Long id) {
+        User user = findUserById(id);
+        return UserContactResDto.from(user);
     }
 }

--- a/auth/src/main/java/com/bobjool/infrastructure/client/NotificationClientImpl.java
+++ b/auth/src/main/java/com/bobjool/infrastructure/client/NotificationClientImpl.java
@@ -1,0 +1,20 @@
+package com.bobjool.infrastructure.client;
+
+import com.bobjool.application.client.NotificationClient;
+import com.bobjool.common.presentation.ApiResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Map;
+
+@FeignClient(name = "notification-service", path = "/api/v1/slack", dismiss404 = true)
+public interface NotificationClientImpl extends NotificationClient {
+
+    @GetMapping("/users")
+    ApiResponse<Map<String, String>> findSlackIdByEmail(
+            @Valid @Email @RequestParam("email") String email
+    );
+}

--- a/auth/src/main/java/com/bobjool/infrastructure/client/NotificationClientImpl.java
+++ b/auth/src/main/java/com/bobjool/infrastructure/client/NotificationClientImpl.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Map;
 
-@FeignClient(name = "notification-service", path = "/api/v1/slack", dismiss404 = true)
+@FeignClient(name = "notification-service", path = "/api/v1/slack")
 public interface NotificationClientImpl extends NotificationClient {
 
     @GetMapping("/users")

--- a/auth/src/main/java/com/bobjool/presentation/controller/AuthController.java
+++ b/auth/src/main/java/com/bobjool/presentation/controller/AuthController.java
@@ -5,7 +5,7 @@ import com.bobjool.common.presentation.ApiResponse;
 import com.bobjool.common.presentation.SuccessCode;
 import com.bobjool.presentation.dto.request.SignInReqDto;
 import com.bobjool.presentation.dto.request.SignUpReqDto;
-import com.bobjool.presentation.dto.response.SignInResDto;
+import com.bobjool.application.dto.SignInResDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/auth/src/main/java/com/bobjool/presentation/controller/AuthController.java
+++ b/auth/src/main/java/com/bobjool/presentation/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.bobjool.presentation.controller;
 
+import com.bobjool.application.dto.UserResDto;
 import com.bobjool.application.service.AuthService;
+import com.bobjool.common.infra.aspect.RequireRole;
 import com.bobjool.common.presentation.ApiResponse;
 import com.bobjool.common.presentation.SuccessCode;
 import com.bobjool.presentation.dto.request.SignInReqDto;
@@ -10,10 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,6 +52,21 @@ public class AuthController {
 
         return ApiResponse.success(
                 SuccessCode.SUCCESS
+        );
+    }
+
+    @RequireRole(value = {"MASTER"})
+    @PatchMapping("/{id}/approval")
+    public ResponseEntity<ApiResponse<UserResDto>> updateUserApproval(
+            @PathVariable Long id,
+            @RequestBody Boolean approved
+    ) {
+
+        UserResDto response = authService.updateUserApproval(id, approved);
+
+        return ApiResponse.success(
+                SuccessCode.SUCCESS_UPDATE,
+                response
         );
     }
 }

--- a/auth/src/main/java/com/bobjool/presentation/controller/UserController.java
+++ b/auth/src/main/java/com/bobjool/presentation/controller/UserController.java
@@ -1,12 +1,14 @@
 package com.bobjool.presentation.controller;
 
+import com.bobjool.application.dto.UserResDto;
 import com.bobjool.application.service.UserService;
+import com.bobjool.common.infra.aspect.RequireRole;
 import com.bobjool.common.presentation.ApiResponse;
 import com.bobjool.common.presentation.PageResponse;
 import com.bobjool.common.presentation.SuccessCode;
 import com.bobjool.presentation.dto.request.UpdateUserReqDto;
-import com.bobjool.presentation.dto.response.UpdateUserResDto;
-import com.bobjool.presentation.dto.response.UserResDto;
+import com.bobjool.application.dto.UpdateUserResDto;
+import com.bobjool.application.dto.UserContactResDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +24,7 @@ public class UserController {
 
     private final UserService userService;
 
+    @RequireRole(value = {"CUSTOMER", "OWNER", "MASTER"})
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<UserResDto>> getUserById(@PathVariable Long id) {
 
@@ -33,6 +36,7 @@ public class UserController {
         );
     }
 
+    @RequireRole(value = {"MASTER"})
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<UserResDto>>> search(
             @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC)
@@ -47,11 +51,11 @@ public class UserController {
         );
     }
 
+    @RequireRole(value = {"CUSTOMER", "OWNER", "MASTER"})
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<UpdateUserResDto>> updateUser(
             @PathVariable Long id,
             @RequestBody UpdateUserReqDto request
-//            HttpServletRequest servletRequest
     ) {
 
         UpdateUserResDto response = userService.updateUser(request.toServiceDto(), id);
@@ -62,6 +66,7 @@ public class UserController {
         );
     }
 
+    @RequireRole(value = {"MASTER"})
     @PatchMapping("/{id}/approval")
     public ResponseEntity<ApiResponse<UserResDto>> updateUserApproval(
             @PathVariable Long id,
@@ -76,6 +81,7 @@ public class UserController {
         );
     }
 
+    @RequireRole(value = {"CUSTOMER", "OWNER", "MASTER"})
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<String>> deleteUser(
             @PathVariable Long id
@@ -85,6 +91,20 @@ public class UserController {
 
         return ApiResponse.success(
                 SuccessCode.SUCCESS_DELETE
+        );
+    }
+
+    @RequireRole(value = {"OWNER", "MASTER"})
+    @GetMapping("/{id}/contact")
+    public ResponseEntity<ApiResponse<UserContactResDto>> getContact(
+            @PathVariable Long id
+    ) {
+
+        UserContactResDto response = userService.getContact(id);
+
+        return ApiResponse.success(
+                SuccessCode.SUCCESS,
+                response
         );
     }
 }

--- a/auth/src/main/java/com/bobjool/presentation/controller/UserController.java
+++ b/auth/src/main/java/com/bobjool/presentation/controller/UserController.java
@@ -66,21 +66,6 @@ public class UserController {
         );
     }
 
-    @RequireRole(value = {"MASTER"})
-    @PatchMapping("/{id}/approval")
-    public ResponseEntity<ApiResponse<UserResDto>> updateUserApproval(
-            @PathVariable Long id,
-            @RequestBody Boolean approved
-    ) {
-
-        UserResDto response = userService.updateUserApproval(id, approved);
-
-        return ApiResponse.success(
-                SuccessCode.SUCCESS_UPDATE,
-                response
-        );
-    }
-
     @RequireRole(value = {"CUSTOMER", "OWNER", "MASTER"})
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<String>> deleteUser(

--- a/config/src/main/resources/config-repo/auth-service.yml
+++ b/config/src/main/resources/config-repo/auth-service.yml
@@ -22,6 +22,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  jackson:
+    property-naming-strategy: SNAKE_CASE
 
 eureka:
   client:


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/auth-dev -> dev
### 이슈
-  #101 
### Description
- 슬랙 이메일을 통해 슬랙 아이디를 가져오는 API를 feign client를 통해 호출하고 회원가입, 회원 정보 수정 API에 적용했습니다.

데이터베이스 조회
![image](https://github.com/user-attachments/assets/ac3109d6-153f-4948-a5b9-b5e9ad537339)

- 사용자 연락처 조회 API 개발하였습니다.
![image](https://github.com/user-attachments/assets/d5155080-da12-44e6-8c31-78ef7c105cb3)
![image](https://github.com/user-attachments/assets/767fbf39-5631-408c-baf7-2350e0d4c30e)

- 오너 승인 API UserService -> AuthService

- SNAKE_CASE 적용

### To Reviewers
- 오너 승인 API UserService에서 AuthService로 옮겼습니다. 엔드포인트 또한 바뀌었으니 참고해주세요.
수정 후 
localhost:19005/api/v1/auths/{id}/approval

- slack id API를 제 이메일로 여러번 호출해봤지만 찾을 수 없다는 에러만 나오더라구요..
지수님 이메일은 잘 돼서 빌렸습니다 :)