### PR TITLE
Feat/Queue -http

### DIFF
--- a/queue/http/queue.http
+++ b/queue/http/queue.http
@@ -1,0 +1,43 @@
+### 대기열 등록(userId 증가시켜서 10명정도 등록해야 순번미루기를 해볼 수 있음)
+POST localhost:19030/api/v1/queues
+Content-Type: application/json
+#Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjdXN0b21lcjEiLCJ1c2VySWQiOiIxIiwicm9sZSI6IkNVU1RPTUVSIiwidG9rZW5UeXBlIjoiYWNjZXNzIiwiaXNzIjoiYXV0aC1zZXJ2aWNlIiwiaWF0IjoxNzM2NjYzMTcxLCJleHAiOjE3MzY2NjM1MzF9.clzcfxYJT8E_vxgvNBcwrB0gLZwl1iQPWGA7Jlgv7Bo
+
+{
+  "user_id": 1,
+  "restaurant_id" : "eaee5a47-50fb-4cf3-9e38-802f492b1630",
+  "member": 4,
+  "type": "ONLINE",
+  "dining_option": "IN_STORE"
+}
+
+### 대기열조회(내순번+뒤로10명)
+GET localhost:19030/api/v1/queues/eaee5a47-50fb-4cf3-9e38-802f492b1630/1
+Content-Type: application/json
+#Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJvd25lcjIzNDUiLCJ1c2VySWQiOiI0Iiwicm9sZSI6Ik9XTkVSIiwidG9rZW5UeXBlIjoiYWNjZXNzIiwiaXNzIjoiYXV0aC1zZXJ2aWNlIiwiaWF0IjoxNzM2NDIzNDAwLCJleHAiOjE3MzY0MjM3NjB9.962LvkRBVw0Am7AUgunNHM4z0Jp1ZfcbNIZkucPH1Fw
+
+### 순번미루기
+POST localhost:19030/api/v1/queues/eaee5a47-50fb-4cf3-9e38-802f492b1630/1?targetUserId=8
+Content-Type: application/json
+#Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjdXN0b21lcjEiLCJ1c2VySWQiOiIxIiwicm9sZSI6IkNVU1RPTUVSIiwidG9rZW5UeXBlIjoiYWNjZXNzIiwiaXNzIjoiYXV0aC1zZXJ2aWNlIiwiaWF0IjoxNzM2NjYzMTcxLCJleHAiOjE3MzY2NjM1MzF9.clzcfxYJT8E_vxgvNBcwrB0gLZwl1iQPWGA7Jlgv7Bo
+
+### 식당체크인
+POST localhost:19030/api/v1/queues/eaee5a47-50fb-4cf3-9e38-802f492b1630/2/check-in
+Content-Type: application/json
+#Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjdXN0b21lcjEiLCJ1c2VySWQiOiIxIiwicm9sZSI6IkNVU1RPTUVSIiwidG9rZW5UeXBlIjoiYWNjZXNzIiwiaXNzIjoiYXV0aC1zZXJ2aWNlIiwiaWF0IjoxNzM2NjYzMTcxLCJleHAiOjE3MzY2NjM1MzF9.clzcfxYJT8E_vxgvNBcwrB0gLZwl1iQPWGA7Jlgv7Bo
+
+### 줄서기 취소
+DELETE localhost:19030/api/v1/queues/eaee5a47-50fb-4cf3-9e38-802f492b1630/1
+Content-Type: application/json
+#Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjdXN0b21lcjEiLCJ1c2VySWQiOiIxIiwicm9sZSI6IkNVU1RPTUVSIiwidG9rZW5UeXBlIjoiYWNjZXNzIiwiaXNzIjoiYXV0aC1zZXJ2aWNlIiwiaWF0IjoxNzM2NjYzMTcxLCJleHAiOjE3MzY2NjM1MzF9.clzcfxYJT8E_vxgvNBcwrB0gLZwl1iQPWGA7Jlgv7Bo
+
+### 식당 입장 알림
+POST localhost:19030/api/v1/queues/eaee5a47-50fb-4cf3-9e38-802f492b1630/3/alert
+Content-Type: application/json
+#Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjdXN0b21lcjEiLCJ1c2VySWQiOiIxIiwicm9sZSI6IkNVU1RPTUVSIiwidG9rZW5UeXBlIjoiYWNjZXNzIiwiaXNzIjoiYXV0aC1zZXJ2aWNlIiwiaWF0IjoxNzM2NjYzMTcxLCJleHAiOjE3MzY2NjM1MzF9.clzcfxYJT8E_vxgvNBcwrB0gLZwl1iQPWGA7Jlgv7Bo
+
+### 식당 입장 호출(재촉) 알림
+POST localhost:19030/api/v1/queues/eaee5a47-50fb-4cf3-9e38-802f492b1630/3/rush
+Content-Type: application/json
+#Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjdXN0b21lcjEiLCJ1c2VySWQiOiIxIiwicm9sZSI6IkNVU1RPTUVSIiwidG9rZW5UeXBlIjoiYWNjZXNzIiwiaXNzIjoiYXV0aC1zZXJ2aWNlIiwiaWF0IjoxNzM2NjYzMTcxLCJleHAiOjE3MzY2NjM1MzF9.clzcfxYJT8E_vxgvNBcwrB0gLZwl1iQPWGA7Jlgv7Bo
+

--- a/queue/src/main/java/com/bobjool/queue/application/service/QueueService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/QueueService.java
@@ -88,8 +88,10 @@ public class QueueService {
 	}
 
 	public void registerQueue(QueueRegisterDto dto) {
+	// public QueueRegisteredEvent registerQueue(QueueRegisterDto dto) {
 		QueueRegisteredEvent event = redisQueueService.registerQueue(dto);
 		queueKafkaProducer.publishQueueRegistered(event);
+		// return event;
 	}
 
 	public QueueStatusResDto getNextTenUsersWithOrder(UUID restaurantId, Long userId) {

--- a/queue/src/main/java/com/bobjool/queue/application/service/RedisQueueService.java
+++ b/queue/src/main/java/com/bobjool/queue/application/service/RedisQueueService.java
@@ -375,7 +375,7 @@ public class RedisQueueService {
 		redisTemplate.opsForHash().put(userQueueDataKey, "delay_count", delayCount + 1);
 	}
 
-	private Double getUserScore(UUID restaurantId, Long userId) {
+	public Double getUserScore(UUID restaurantId, Long userId) {
 		String waitingListKey = RedisKeyUtil.getWaitingListKey(restaurantId);
 		Double score = redisTemplate.opsForZSet().score(waitingListKey, String.valueOf(userId));
 		if (score == null) {

--- a/queue/src/main/java/com/bobjool/queue/presentation/controller/QueueController.java
+++ b/queue/src/main/java/com/bobjool/queue/presentation/controller/QueueController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.bobjool.common.presentation.ApiResponse;
 import com.bobjool.common.presentation.SuccessCode;
 import com.bobjool.queue.application.dto.QueueStatusResDto;
+import com.bobjool.queue.application.dto.kafka.QueueRegisteredEvent;
 import com.bobjool.queue.application.dto.redis.QueueAlertDto;
 import com.bobjool.queue.application.dto.redis.QueueCancelDto;
 import com.bobjool.queue.application.dto.redis.QueueCheckInDto;
@@ -39,6 +40,12 @@ public class QueueController {
 		return ApiResponse.success(SuccessCode.SUCCESS_ACCEPTED,
 			queueService.handleQueue(request.restaurantId(), request.userId(), request.toServiceDto(), "register"));
 	}
+	// @PostMapping("/queues")
+	// public ResponseEntity<ApiResponse<QueueRegisteredEvent>> registerQueue(
+	// 	@Valid @RequestBody QueueRegisterReqDto request) {
+	// 	return ApiResponse.success(SuccessCode.SUCCESS_ACCEPTED,
+	// 		queueService.registerQueue(request.toServiceDto()));
+	// }
 
 	@GetMapping("/queues/{restaurantId}/{userId}")
 	public ResponseEntity<ApiResponse<QueueStatusResDto>> getNextTenUsersWithOrder(


### PR DESCRIPTION
### PR 타입
- [] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/Queue -http -> dev
### 이슈
- #118
### Description
- queeu.http 작성
- 동시성 테스트(같은 식당열에, 체크인, 취소, 미루기, 등록 한꺼번에) 
- 1. 테스트 전 데이터
 ![image](https://github.com/user-attachments/assets/07686e22-0e12-4080-afe1-6e492ba665c4)
- 2. 기대값
    1.  2번 체크인(대기열에서 삭제, iswaiting에서 삭제, status 체크인)
    2.  3번 취소(대기열에서 삭제, iswaiting에서 삭제, status 캔슬)
    3.  4번 미루기 5번 뒤로(대기열 score 5.5, status 딜레이드)
    4. 11번 등록(대기열 스코어 11, iswaiong에 생김, status 웨이팅)
- 3. 결과
![image](https://github.com/user-attachments/assets/345dc84f-c47a-4d5b-aa31-57731bacdf22)

코드 정리
### To Reviewers
- 테스트는 성공했는데, buid는 안되서 코드는 올리지 않았습니다!
 ![image](https://github.com/user-attachments/assets/3be7fbbc-e294-4b90-9f60-d4874fd8e083)