### PR TITLE
Fix/Auth-slack_email은 null일시 중복 검사에서 제외

### DIFF
--- a/auth/src/main/java/com/bobjool/application/service/ValidationService.java
+++ b/auth/src/main/java/com/bobjool/application/service/ValidationService.java
@@ -25,8 +25,10 @@ public class ValidationService {
     }
 
     public void validateDuplicateSlackEmail(String slackEmail) {
-        if (userRepository.findBySlackEmail(slackEmail).isPresent()) {
-            throw new BobJoolException(ErrorCode.DUPLICATE_SLACK_EMAIL);
+        if (slackEmail != null) {
+            if (userRepository.findBySlackEmail(slackEmail).isPresent()) {
+                throw new BobJoolException(ErrorCode.DUPLICATE_SLACK_EMAIL);
+            }
         }
     }
 


### PR DESCRIPTION
### PR 타입
- [] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/auth-dev -> dev
### 이슈
- #101
### Description
- 회원가입시 slack email은 null은 중복 검사에서 제외하였습니다.
slack email은 null 허용이지만 기존의 있는 다른 데이터가 null이면 중복으로 처리하는 문제가 있었습니다.
### To Reviewers
- 리뷰받고 싶은 부분에 대해 작성