### PR TITLE
Feat/notification - 이메일 전송 기능 구현

### DIFF
--- a/common/src/main/java/com/bobjool/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/bobjool/common/exception/ErrorCode.java
@@ -92,6 +92,7 @@ public enum ErrorCode {
     // 알림
     INVALID_SLACK_EMAIL(HttpStatus.BAD_REQUEST, "유효하지 않은 Slack 이메일입니다."),
     SLACK_MESSAGE_SEND_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "Slack 알림 메시지를 전송하지 못했습니다."),
+    MAIL_MESSAGE_SEND_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "메일 알림 메시지를 전송하지 못했습니다."),
     UNSUPPORTED_SERVICE(HttpStatus.BAD_REQUEST, "지원하지 않는 서비스입니다."),
     UNSUPPORTED_CHANNEL(HttpStatus.BAD_REQUEST, "지원하지 않는 채널입니다."),
     UNSUPPORTED_NOTIFICATION(HttpStatus.BAD_REQUEST, "지원하지 않는 알림 종류입니다."),

--- a/config/src/main/resources/config-repo/notification-service.yml
+++ b/config/src/main/resources/config-repo/notification-service.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: notification-service
   config:
-      import: classpath:config-repo/application-key.yml
+    import: classpath:config-repo/application-key.yml
   datasource:
     driver-class-name: org.postgresql.Driver
     url: ${DB_URL}/notification_db
@@ -29,6 +29,17 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       group-id: ${spring.application.name}-group
     bootstrap-servers: ${KAFKA_SERVER_URL}
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${SENDER_ACCOUNT}
+    password: ${SENDER_PASSWORD}
+    properties:
+      mail.smtp.debug: true
+      mail.smtp.connectiontimeout: 1000 #1초
+      mail.starttls.enable: true
+      mail.smtp.auth: true
+
 
 notification:
   template-mapping:

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+    // Mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/notification/src/main/java/com/bobjool/notification/application/service/EventService.java
+++ b/notification/src/main/java/com/bobjool/notification/application/service/EventService.java
@@ -89,6 +89,12 @@ public class EventService {
         NotificationDto dto = NotificationDto.from(details);
         messagingService.postNotification(dto);
         log.info("Notification posted successfully");
+
+//        details.updateEmailChannel();
+//        details.applyMessageTypeMail();
+//        NotificationDto dto = NotificationDto.from(details);
+//        messagingService.postNotification(dto);
+
     }
 
     @Transactional

--- a/notification/src/main/java/com/bobjool/notification/application/service/MailService.java
+++ b/notification/src/main/java/com/bobjool/notification/application/service/MailService.java
@@ -1,0 +1,37 @@
+package com.bobjool.notification.application.service;
+
+import com.bobjool.common.exception.BobJoolException;
+import com.bobjool.common.exception.ErrorCode;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class MailService {
+    private final JavaMailSender javaMailSender;
+
+    @Async
+    public void sendEmailNotification(String email, String title, String content) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject(title);
+            mimeMessageHelper.setText(content);
+            javaMailSender.send(mimeMessage);
+
+            log.info("Succeeded to send Email");
+        } catch (Exception e) {
+            log.info("Failed to send Email");
+            throw new BobJoolException(ErrorCode.MAIL_MESSAGE_SEND_FAILED);
+        }
+    }
+}

--- a/notification/src/main/java/com/bobjool/notification/application/service/MailService.java
+++ b/notification/src/main/java/com/bobjool/notification/application/service/MailService.java
@@ -25,7 +25,7 @@ public class MailService {
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
             mimeMessageHelper.setTo(email);
             mimeMessageHelper.setSubject(title);
-            mimeMessageHelper.setText(content);
+            mimeMessageHelper.setText(content,true);
             javaMailSender.send(mimeMessage);
 
             log.info("Succeeded to send Email");

--- a/notification/src/main/java/com/bobjool/notification/application/service/MessagingService.java
+++ b/notification/src/main/java/com/bobjool/notification/application/service/MessagingService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MessagingService {
     private final SlackService slackService;
+    private final MailService mailService;
 
     @Transactional
     public void postNotification(NotificationDto dto) {
@@ -32,8 +33,8 @@ public class MessagingService {
         slackService.chatPostMessage(channelId, message);
     }
 
-    private void sendEmail(String email, String title, String content) {
-        // TODO. Email 라이브러리 적용
+    public void sendEmail(String email, String title, String content) {
+        mailService.sendEmailNotification(email, title, content);
     }
 
 }

--- a/notification/src/main/java/com/bobjool/notification/domain/service/NotificationDetails.java
+++ b/notification/src/main/java/com/bobjool/notification/domain/service/NotificationDetails.java
@@ -73,9 +73,19 @@ public class NotificationDetails {
         }
         return UUID.fromString(metaData.get(RESTAURANT_ID.toCamelCase()));
     }
+
+    public void updateSlackChannel(){
+        this.messageChannel = NotificationChannel.SLACK;
+    }
+
+    public void updateEmailChannel(){
+        this.messageChannel = NotificationChannel.EMAIL;
+    }
+
     public void updateTemplateData(String templateData) {
         this.templateData = templateData;
     }
+
     public void updateUserContact(String name, String slack, String email) {
         metaData.put(USER_NAME.toSnakeCase(), name);
         metaData.put(USER_SLACK.toSnakeCase(), slack);
@@ -130,8 +140,26 @@ public class NotificationDetails {
         return "*".concat(text).concat("*");
     }
 
+    private String removeBoldStyle(String text) {
+        return text.replace("*","");
+    }
+
     private String addLineBreak(String text) {
         return text.concat("\n");
+    }
+
+    private String removeLineBreak(String text) {
+        return text.replace("\n","");
+    }
+
+    public void applyMessageTypeMail(){
+        messageTitle = removeBoldStyle(messageTitle);
+        messageTitle = removeLineBreak(messageTitle);
+        messageContent = changeLineBreakHTML(this.messageContent);
+    }
+
+    private String changeLineBreakHTML(String text) {
+        return text.replace("\n", "<br/>");
     }
 
     public String getJsonMetaData(){

--- a/notification/src/main/java/com/bobjool/notification/infrastructure/config/mail/MailConfig.java
+++ b/notification/src/main/java/com/bobjool/notification/infrastructure/config/mail/MailConfig.java
@@ -1,0 +1,63 @@
+package com.bobjool.notification.infrastructure.config.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@RequiredArgsConstructor
+public class MailConfig {
+    private static final String MAIL_SMTP_AUTH = "mail.smtp.auth";
+    private static final String MAIL_DEBUG = "mail.smtp.debug";
+    private static final String MAIL_CONNECTION_TIMEOUT = "mail.smtp.connectiontimeout";
+    private static final String MAIL_SMTP_STARTTLS_ENABLE = "mail.smtp.starttls.enable";
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.debug}")
+    private boolean debug;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.starttls.enable}")
+    private boolean startTlsEnable;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost(host);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(port);
+
+        Properties properties = javaMailSender.getJavaMailProperties();
+        properties.put(MAIL_SMTP_AUTH, auth);
+        properties.put(MAIL_DEBUG, debug);
+        properties.put(MAIL_CONNECTION_TIMEOUT, connectionTimeout);
+        properties.put(MAIL_SMTP_STARTTLS_ENABLE, startTlsEnable);
+
+        javaMailSender.setJavaMailProperties(properties);
+        javaMailSender.setDefaultEncoding("UTF-8");
+
+        return javaMailSender;
+    }
+}

--- a/notification/src/main/java/com/bobjool/notification/presentation/controller/MessagingController.java
+++ b/notification/src/main/java/com/bobjool/notification/presentation/controller/MessagingController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/notifications")
+@RequestMapping("/api/v1/notifications/message")
 @RequiredArgsConstructor
 public class MessagingController {
     private final MessagingService messagingService;


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/notification-email -> dev
### 이슈
- #114
### Description
- 카프카 메시지에서 슬랙 포맷(마크다운)에서 이메일 포맷(HTML)으로 변경하고 이메일 라이브러리를 통해 전송합니다.
![image](https://github.com/user-attachments/assets/3a655a80-e154-42cd-82b7-a3aef1f4e4fd)
![image](https://github.com/user-attachments/assets/2106e03d-d930-45df-9aba-1e8ced3ff8ba)

### To Reviewers
- 서킷 브레이커 적용은 설정 관련 조사가 필요해서 전송 기능만 먼저 올렸습니다.
- [Slack에 공용 key 파일 업데이트 했습니다.](https://bobjool.slack.com/archives/C086U74C537/p1736925848150899)
- 이전 PR에서 컨트롤러의 엔드포인트가 겹치는 부분을 수정했습니다.