### PR TITLE
Feat/notification - 서킷 브레이커 적용 및 알림 발송 상태 히스토리 반영

### DIFF
--- a/config/src/main/resources/config-repo/notification-service.yml
+++ b/config/src/main/resources/config-repo/notification-service.yml
@@ -28,7 +28,13 @@ spring:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       group-id: ${spring.application.name}-group
+      enable:
+        auto:
+          commit: false
     bootstrap-servers: ${KAFKA_SERVER_URL}
+    listener:
+      concurrency: 3
+      ack-mode: manual
   mail:
     host: smtp.gmail.com
     port: 587
@@ -60,6 +66,27 @@ token:
   slack:
     oauth: ${SLACK_OAUTH_TOKEN}
 
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        registerHealthIndicator: true             # actuator - 매트릭 추가 여부
+        eventConsumerBufferSize: 10               # actuator - 발생한 이벤트 버퍼 크기
+        slidingWindowType: COUNT_BASED            # 알고리즘 - 타입
+        slidingWindowSize: 10                     # 알고리즘 - 범위, 최근 n회 기준
+        failureRateThreshold: 20                  # 실패 - 임계 값 퍼센트
+        minimumNumberOfCalls: 10                  # 실패 - 집계에 필요한 최소 호출 수
+        slowCallRateThreshold: 80                 # 지연 - 느린 호출의 비율 %
+        slowCallDurationThreshold: 30000          # 지연 - 느린 호출의 기준 (밀리초)
+        permittedNumberOfCallsInHalfOpenState: 3  # Half-open 상태에서 최대 호출 수
+        waitDurationInOpenState: 60s              # Half-open 전환 대기 시간
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+#        record-exceptions:
+#          - com.bobjool.common.exception.BobJoolException
+    instances:
+      pushNotificationToSlack:
+        baseConfig: default
+
 management:
   zipkin:
     tracing:
@@ -71,3 +98,9 @@ management:
     web:
       exposure:
         include: "*"
+
+logging:
+  level:
+    io.github.resilience4j: DEBUG
+    org.springframework.kafka: DEBUG
+    com.bobjool: DEBUG

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -30,10 +30,13 @@ dependencies {
     // Mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-    //config server
+    // config server
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Resilience4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/notification/src/main/java/com/bobjool/notification/application/service/EventService.java
+++ b/notification/src/main/java/com/bobjool/notification/application/service/EventService.java
@@ -33,14 +33,13 @@ public class EventService {
     private final RestaurantClient restaurantClient;
     private final CircuitBreakerRegistry circuitBreakerRegistry;
 
-    public void processNotification(NotificationDetails details) throws Exception {
+    public void processNotification(NotificationDetails details) {
         loadContacts(details);
         bindToTemplate(details);
         UUID notificationId = saveHistory(details);
         pushNotificationToSlack(notificationId, details);
     }
 
-    @Transactional(readOnly = true)
     protected void bindToTemplate(NotificationDetails details) {
         TemplateDto template = templateService.selectTemplate(details.getTemplateId());
         String messageContent = templateConvertService.templateBinding(template.template(), details.getMetaData());
@@ -50,7 +49,6 @@ public class EventService {
         details.applyMessageTitleStyle();
     }
 
-    @Transactional
     protected UUID saveHistory(NotificationDetails details) {
         return historyService.saveNotification(
                 details.getTemplateId(),

--- a/notification/src/main/java/com/bobjool/notification/application/service/MessagingService.java
+++ b/notification/src/main/java/com/bobjool/notification/application/service/MessagingService.java
@@ -1,7 +1,6 @@
 package com.bobjool.notification.application.service;
 
 import com.bobjool.notification.application.dto.NotificationDto;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,24 +10,15 @@ public class MessagingService {
     private final SlackService slackService;
     private final MailService mailService;
 
-    @Transactional
     public void postNotification(NotificationDto dto) {
-        switch (dto.messageChannel()) {
-            case SLACK:
-                sendDirectMessage(
-                        dto.userSlack(),
-                        dto.messageTitle().concat(
-                                dto.messageContent())
-                );
-                break;
-            case EMAIL:
-            default:
-                sendEmail(dto.userEmail(), dto.messageTitle(), dto.messageContent());
-        }
-
+        sendDirectMessage(
+                dto.userSlack(),
+                dto.messageTitle().concat(
+                        dto.messageContent())
+        );
     }
 
-    private void sendDirectMessage(String slackId, String message) {
+    public void sendDirectMessage(String slackId, String message) {
         String channelId = slackService.conversationsOpen(slackId);
         slackService.chatPostMessage(channelId, message);
     }

--- a/notification/src/main/java/com/bobjool/notification/application/service/TemplateService.java
+++ b/notification/src/main/java/com/bobjool/notification/application/service/TemplateService.java
@@ -94,7 +94,8 @@ public class TemplateService {
         return TemplateDto.from(template);
     }
 
-    private Template getTemplateById(UUID templateId) {
+    @Transactional(readOnly = true)
+    protected Template getTemplateById(UUID templateId) {
         return templateRepository.findByIdAndDeletedAtIsNull(templateId)
                 .orElseThrow(
                         () -> new BobJoolException(ErrorCode.ENTITY_NOT_FOUND)

--- a/notification/src/main/java/com/bobjool/notification/domain/entity/Notification.java
+++ b/notification/src/main/java/com/bobjool/notification/domain/entity/Notification.java
@@ -45,7 +45,12 @@ public class Notification extends BaseEntity {
                 .jsonData(jsonData)
                 .message(message)
                 .contact(contact)
-                .status(NotificationStatus.SENT)
+                .status(NotificationStatus.PENDING)
                 .build();
     }
+
+    public void updateStatus(NotificationStatus status) {
+        this.status = status;
+    }
+
 }

--- a/notification/src/main/java/com/bobjool/notification/domain/repository/NotificationRepository.java
+++ b/notification/src/main/java/com/bobjool/notification/domain/repository/NotificationRepository.java
@@ -8,12 +8,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * 도메인 관점 인터페이스
  */
 public interface NotificationRepository {
     Notification save(Notification notification);
+
+    Optional<Notification> findById(UUID id);
 
     Page<Notification> search(
             Long userId,

--- a/notification/src/main/java/com/bobjool/notification/infrastructure/config/circuit/CircuitBreakerConsumerConfiguration.java
+++ b/notification/src/main/java/com/bobjool/notification/infrastructure/config/circuit/CircuitBreakerConsumerConfiguration.java
@@ -1,0 +1,37 @@
+package com.bobjool.notification.infrastructure.config.circuit;
+
+import com.bobjool.notification.infrastructure.messaging.KafkaManager;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j(topic = "CircuitBreakerConsumerConfiguration")
+@Configuration
+public class CircuitBreakerConsumerConfiguration {
+    public CircuitBreakerConsumerConfiguration(CircuitBreakerRegistry circuitBreakerRegistry, KafkaManager kafkaManager) {
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker("pushNotificationToSlack");
+
+        circuitBreaker.getEventPublisher().onStateTransition(event -> {
+
+            CircuitBreaker.StateTransition transition = event.getStateTransition();
+            log.info("CircuitBreaker has changed status: {}", transition);
+
+            switch (transition) {
+                case CLOSED_TO_OPEN:
+                case CLOSED_TO_FORCED_OPEN:
+                case HALF_OPEN_TO_OPEN:
+                    kafkaManager.pause();
+                    break;
+                case OPEN_TO_HALF_OPEN:
+                case HALF_OPEN_TO_CLOSED:
+                case FORCED_OPEN_TO_CLOSED:
+                case FORCED_OPEN_TO_HALF_OPEN:
+                    kafkaManager.resume();
+                    break;
+                default:
+                    log.warn("CircuitBreaker changed to unknown state: {}", transition);
+            }
+        });
+    }
+}

--- a/notification/src/main/java/com/bobjool/notification/infrastructure/messaging/KafkaManager.java
+++ b/notification/src/main/java/com/bobjool/notification/infrastructure/messaging/KafkaManager.java
@@ -1,0 +1,28 @@
+package com.bobjool.notification.infrastructure.messaging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "KafkaManager")
+@Component
+public class KafkaManager {
+    private final KafkaListenerEndpointRegistry registry;
+
+    @Autowired
+    public KafkaManager(KafkaListenerEndpointRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void pause() {
+        log.info("Pause all Kafka listener containers");
+        registry.getListenerContainers().forEach(MessageListenerContainer::pause);
+    }
+
+    public void resume() {
+        log.info("Resume all Kafka listener containers");
+        registry.getListenerContainers().forEach(MessageListenerContainer::resume);
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/notification-fallback -> dev
### 이슈
- #129 
- #114
### Description
- 슬랙 서버가 문제가 있다고 판단되면 DM 발송 대신 이메일 발송으로 대체하도록 서킷 브레이커를 적용하였습니다.
- 알림 발송 상태를 히스토리에 반영하는 로직이 추가되었습니다.
### To Reviewers
- [노션 페이지](https://www.notion.so/Resilience4j-17d133b141d6803f90bbf8b7fbfd993e)에 관련해서 정리하도록 하겠습니다.