### PR TITLE
[config] feat: main, dev 환경 git private repo 사용으로 전부 변경 / prod 환경은 미적용

### DIFF
--- a/auth/src/main/resources/application-dev.yml
+++ b/auth/src/main/resources/application-dev.yml
@@ -5,6 +5,8 @@ spring:
     import: "configserver:"
   cloud:
     config:
+      uri: http://localhost:19002 # Config Server 주소
+      label: dev # Git 브랜치
       discovery:
         service-id: config-service
         enabled: true

--- a/auth/src/main/resources/application.yml
+++ b/auth/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
+  application:
+    name: auth-service
   profiles:
     default: dev

--- a/config/src/main/resources/config-repo/auth-service.yml
+++ b/config/src/main/resources/config-repo/auth-service.yml
@@ -1,62 +1,62 @@
-server:
-  port: 19010
-
-spring:
-  application:
-    name: auth-service
-  config:
-    import: classpath:config-repo/application-key.yml
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: ${DB_URL}/user_db
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      format-sql: true
-      use_sql_comments: true
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-  data:
-    redis:
-      host: ${SHARED_REDIS_HOSTNAME}
-      port: ${SHARED_REDIS_PORT}
-  jackson:
-    property-naming-strategy: SNAKE_CASE
-
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: http://localhost:19000/eureka/
-
-service:
-  jwt:
-    access-expiration: 360000
-    secret-key: "401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b3727429080fb337591abd3e44453b954555b7a0812e1081c39b740293f765eae731f5a65ed1"
-
-management:
-  zipkin:
-    tracing:
-      endpoint: "http://localhost:9411/api/v2/spans"
-  tracing:
-    sampling:
-      probability: 1.0
-
-  #모든 엔드포인트 노출 설정
-  endpoints:
-    web:
-      exposure:
-        include: "*"
-    #헬스 체크 엔드포인트 상세 정보 표시 설정
-    health:
-      show-details: always
-
-  #프로메테우스 사용활성화
-  metrics:
-    export:
-      prometheus:
-        enabled: true
-
+#server:
+#  port: 19010
+#
+#spring:
+#  application:
+#    name: auth-service
+#  config:
+#    import: classpath:config-repo/application-key.yml
+#  datasource:
+#    driver-class-name: org.postgresql.Driver
+#    url: ${DB_URL}/user_db
+#    username: ${DB_USERNAME}
+#    password: ${DB_PASSWORD}
+#  jpa:
+#    hibernate:
+#      ddl-auto: update
+#    show-sql: true
+#    properties:
+#      format-sql: true
+#      use_sql_comments: true
+#      hibernate:
+#        dialect: org.hibernate.dialect.PostgreSQLDialect
+#  data:
+#    redis:
+#      host: ${SHARED_REDIS_HOSTNAME}
+#      port: ${SHARED_REDIS_PORT}
+#  jackson:
+#    property-naming-strategy: SNAKE_CASE
+#
+#eureka:
+#  client:
+#    serviceUrl:
+#      defaultZone: http://localhost:19000/eureka/
+#
+#service:
+#  jwt:
+#    access-expiration: 360000
+#    secret-key: "401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b3727429080fb337591abd3e44453b954555b7a0812e1081c39b740293f765eae731f5a65ed1"
+#
+#management:
+#  zipkin:
+#    tracing:
+#      endpoint: "http://localhost:9411/api/v2/spans"
+#  tracing:
+#    sampling:
+#      probability: 1.0
+#
+#  #모든 엔드포인트 노출 설정
+#  endpoints:
+#    web:
+#      exposure:
+#        include: "*"
+#    #헬스 체크 엔드포인트 상세 정보 표시 설정
+#    health:
+#      show-details: always
+#
+#  #프로메테우스 사용활성화
+#  metrics:
+#    export:
+#      prometheus:
+#        enabled: true
+#

--- a/config/src/main/resources/config-repo/notification-service.yml
+++ b/config/src/main/resources/config-repo/notification-service.yml
@@ -1,117 +1,117 @@
-server:
-  port: 19050
-
-spring:
-  application:
-    name: notification-service
-  config:
-    import: classpath:config-repo/application-key.yml
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: ${DB_URL}/notification_db
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-  jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      format-sql: true
-      use_sql_comments: true
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-  jackson:
-    property-naming-strategy: SNAKE_CASE
-  kafka:
-    consumer:
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      group-id: ${spring.application.name}-group
-      enable:
-        auto:
-          commit: false
-    bootstrap-servers: ${KAFKA_SERVER_URL}
-    listener:
-      concurrency: 3
-      ack-mode: manual
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${SENDER_ACCOUNT}
-    password: ${SENDER_PASSWORD}
-    properties:
-      mail.smtp.debug: true
-      mail.smtp.connectiontimeout: 1000 #1초
-      mail.starttls.enable: true
-      mail.smtp.auth: true
-
-
-notification:
-  template-mapping:
-    queue:
-      registered: 9d5b1a23-eb4c-44b8-8f20-d7f19254b364
-      delayed: 0a6aab9f-7656-45d8-97c3-63b9cc9eac35
-      remind: b64b7920-68ea-470f-adba-2c4a0a5af031
-      alerted: 33c5002a-8041-496f-80af-b4953b987c90
-      rush: 0297236f-4b16-4ffa-8614-ce60a073a857
-      canceled: 35733f44-8e0b-4c0a-bff8-03390fb0c39f
-    reservation:
-      completed: d2fae87a-60eb-4684-9fb6-c6a53a78f8e7
-      failed: fb348681-f0ae-42ec-970d-c9b5d4bb6ff0
-      refund: 237c2474-2509-4dfa-aeb2-4eb9f421ef9d
-      remind: 14e786a6-7757-4809-87fb-d7665e79d141
-
-token:
-  slack:
-    oauth: ${SLACK_OAUTH_TOKEN}
-
-resilience4j:
-  circuitbreaker:
-    configs:
-      default:
-        registerHealthIndicator: true             # actuator - 매트릭 추가 여부
-        eventConsumerBufferSize: 10               # actuator - 발생한 이벤트 버퍼 크기
-        slidingWindowType: COUNT_BASED            # 알고리즘 - 타입
-        slidingWindowSize: 10                     # 알고리즘 - 범위, 최근 n회 기준
-        failureRateThreshold: 20                  # 실패 - 임계 값 퍼센트
-        minimumNumberOfCalls: 10                  # 실패 - 집계에 필요한 최소 호출 수
-        slowCallRateThreshold: 80                 # 지연 - 느린 호출의 비율 %
-        slowCallDurationThreshold: 30000          # 지연 - 느린 호출의 기준 (밀리초)
-        permittedNumberOfCallsInHalfOpenState: 3  # Half-open 상태에서 최대 호출 수
-        waitDurationInOpenState: 60s              # Half-open 전환 대기 시간
-        automaticTransitionFromOpenToHalfOpenEnabled: true
-#        record-exceptions:
-#          - com.bobjool.common.exception.BobJoolException
-    instances:
-      pushNotificationToSlack:
-        baseConfig: default
-
-management:
-  zipkin:
-    tracing:
-      endpoint: "http://localhost:9411/api/v2/spans"
-  tracing:
-    sampling:
-      probability: 1.0
-
-  #모든 엔드포인트 노출 설정
-  endpoints:
-    web:
-      exposure:
-        include: "*"
-  #헬스 체크 엔드포인트 상세 정보 표시 설정
-  health:
-    show-details: always
-
-  #프로메테우스 사용활성화
-  metrics:
-    export:
-      prometheus:
-        enabled: true
-
-logging:
-  level:
-    io.github.resilience4j: DEBUG
-    org.springframework.kafka: DEBUG
-    com.bobjool: DEBUG
+#server:
+#  port: 19050
+#
+#spring:
+#  application:
+#    name: notification-service
+#  config:
+#    import: classpath:config-repo/application-key.yml
+#  datasource:
+#    driver-class-name: org.postgresql.Driver
+#    url: ${DB_URL}/notification_db
+#    username: ${DB_USERNAME}
+#    password: ${DB_PASSWORD}
+#  jpa:
+#    database-platform: org.hibernate.dialect.PostgreSQLDialect
+#    hibernate:
+#      ddl-auto: update
+#    show-sql: true
+#    properties:
+#      format-sql: true
+#      use_sql_comments: true
+#      hibernate:
+#        dialect: org.hibernate.dialect.PostgreSQLDialect
+#  jackson:
+#    property-naming-strategy: SNAKE_CASE
+#  kafka:
+#    consumer:
+#      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+#      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+#      group-id: ${spring.application.name}-group
+#      enable:
+#        auto:
+#          commit: false
+#    bootstrap-servers: ${KAFKA_SERVER_URL}
+#    listener:
+#      concurrency: 3
+#      ack-mode: manual
+#  mail:
+#    host: smtp.gmail.com
+#    port: 587
+#    username: ${SENDER_ACCOUNT}
+#    password: ${SENDER_PASSWORD}
+#    properties:
+#      mail.smtp.debug: true
+#      mail.smtp.connectiontimeout: 1000 #1초
+#      mail.starttls.enable: true
+#      mail.smtp.auth: true
+#
+#
+#notification:
+#  template-mapping:
+#    queue:
+#      registered: 9d5b1a23-eb4c-44b8-8f20-d7f19254b364
+#      delayed: 0a6aab9f-7656-45d8-97c3-63b9cc9eac35
+#      remind: b64b7920-68ea-470f-adba-2c4a0a5af031
+#      alerted: 33c5002a-8041-496f-80af-b4953b987c90
+#      rush: 0297236f-4b16-4ffa-8614-ce60a073a857
+#      canceled: 35733f44-8e0b-4c0a-bff8-03390fb0c39f
+#    reservation:
+#      completed: d2fae87a-60eb-4684-9fb6-c6a53a78f8e7
+#      failed: fb348681-f0ae-42ec-970d-c9b5d4bb6ff0
+#      refund: 237c2474-2509-4dfa-aeb2-4eb9f421ef9d
+#      remind: 14e786a6-7757-4809-87fb-d7665e79d141
+#
+#token:
+#  slack:
+#    oauth: ${SLACK_OAUTH_TOKEN}
+#
+#resilience4j:
+#  circuitbreaker:
+#    configs:
+#      default:
+#        registerHealthIndicator: true             # actuator - 매트릭 추가 여부
+#        eventConsumerBufferSize: 10               # actuator - 발생한 이벤트 버퍼 크기
+#        slidingWindowType: COUNT_BASED            # 알고리즘 - 타입
+#        slidingWindowSize: 10                     # 알고리즘 - 범위, 최근 n회 기준
+#        failureRateThreshold: 20                  # 실패 - 임계 값 퍼센트
+#        minimumNumberOfCalls: 10                  # 실패 - 집계에 필요한 최소 호출 수
+#        slowCallRateThreshold: 80                 # 지연 - 느린 호출의 비율 %
+#        slowCallDurationThreshold: 30000          # 지연 - 느린 호출의 기준 (밀리초)
+#        permittedNumberOfCallsInHalfOpenState: 3  # Half-open 상태에서 최대 호출 수
+#        waitDurationInOpenState: 60s              # Half-open 전환 대기 시간
+#        automaticTransitionFromOpenToHalfOpenEnabled: true
+##        record-exceptions:
+##          - com.bobjool.common.exception.BobJoolException
+#    instances:
+#      pushNotificationToSlack:
+#        baseConfig: default
+#
+#management:
+#  zipkin:
+#    tracing:
+#      endpoint: "http://localhost:9411/api/v2/spans"
+#  tracing:
+#    sampling:
+#      probability: 1.0
+#
+#  #모든 엔드포인트 노출 설정
+#  endpoints:
+#    web:
+#      exposure:
+#        include: "*"
+#  #헬스 체크 엔드포인트 상세 정보 표시 설정
+#  health:
+#    show-details: always
+#
+#  #프로메테우스 사용활성화
+#  metrics:
+#    export:
+#      prometheus:
+#        enabled: true
+#
+#logging:
+#  level:
+#    io.github.resilience4j: DEBUG
+#    org.springframework.kafka: DEBUG
+#    com.bobjool: DEBUG

--- a/config/src/main/resources/config-repo/payment-service.yml
+++ b/config/src/main/resources/config-repo/payment-service.yml
@@ -1,72 +1,72 @@
-server:
-  port: 19060
-
-spring:
-  application:
-    name: payment-service
-  config:
-    import: classpath:config-repo/application-key.yml
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: ${DB_URL}/payment_db
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      format-sql: true
-      use_sql_comments: true
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-  jackson:
-    property-naming-strategy: SNAKE_CASE
-  kafka:
-    bootstrap-servers: ${KAFKA_SERVER_URL}
-    consumer: # TODO kafka consumer, producer에 대한 설정값 수정은 여기에서
-      group-id: ${spring.application.name}-group
-      auto-offset-reset: earliest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: '*'
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-  data:
-    redis:
-      host: ${SHARED_REDIS_HOSTNAME}
-      port: ${SHARED_REDIS_PORT}
-
-
-
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: http://localhost:19000/eureka/
-
-
-
-management:
-  zipkin:
-    tracing:
-      endpoint: "http://localhost:9411/api/v2/spans"
-  tracing:
-    sampling:
-      probability: 1.0
-
-  #모든 엔드포인트 노출 설정
-  endpoints:
-    web:
-      exposure:
-        include: "*"
-    #헬스 체크 엔드포인트 상세 정보 표시 설정
-    health:
-      show-details: always
-
-  #프로메테우스 사용활성화
-  metrics:
-    export:
-      prometheus:
-        enabled: true
+#server:
+#  port: 19060
+#
+#spring:
+#  application:
+#    name: payment-service
+#  config:
+#    import: classpath:config-repo/application-key.yml
+#  datasource:
+#    driver-class-name: org.postgresql.Driver
+#    url: ${DB_URL}/payment_db
+#    username: ${DB_USERNAME}
+#    password: ${DB_PASSWORD}
+#  jpa:
+#    hibernate:
+#      ddl-auto: update
+#    show-sql: true
+#    properties:
+#      format-sql: true
+#      use_sql_comments: true
+#      hibernate:
+#        dialect: org.hibernate.dialect.PostgreSQLDialect
+#  jackson:
+#    property-naming-strategy: SNAKE_CASE
+#  kafka:
+#    bootstrap-servers: ${KAFKA_SERVER_URL}
+#    consumer: # TODO kafka consumer, producer에 대한 설정값 수정은 여기에서
+#      group-id: ${spring.application.name}-group
+#      auto-offset-reset: earliest
+#      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+#      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+#      properties:
+#        spring.json.trusted.packages: '*'
+#    producer:
+#      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+#      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+#  data:
+#    redis:
+#      host: ${SHARED_REDIS_HOSTNAME}
+#      port: ${SHARED_REDIS_PORT}
+#
+#
+#
+#eureka:
+#  client:
+#    serviceUrl:
+#      defaultZone: http://localhost:19000/eureka/
+#
+#
+#
+#management:
+#  zipkin:
+#    tracing:
+#      endpoint: "http://localhost:9411/api/v2/spans"
+#  tracing:
+#    sampling:
+#      probability: 1.0
+#
+#  #모든 엔드포인트 노출 설정
+#  endpoints:
+#    web:
+#      exposure:
+#        include: "*"
+#    #헬스 체크 엔드포인트 상세 정보 표시 설정
+#    health:
+#      show-details: always
+#
+#  #프로메테우스 사용활성화
+#  metrics:
+#    export:
+#      prometheus:
+#        enabled: true

--- a/config/src/main/resources/config-repo/queue-service.yml
+++ b/config/src/main/resources/config-repo/queue-service.yml
@@ -1,72 +1,72 @@
-server:
-  port: 19030
-
-spring:
-  application:
-    name: queue-service
-  config:
-    import: classpath:config-repo/application-key.yml
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: ${DB_URL}/queue_db
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-  data:
-    redis:
-      host: ${QUEUE_REDIS_HOSTNAME}
-      port: ${QUEUE_REDIS_PORT}
-#      username: default
-#      password: password
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      format-sql: true
-      use_sql_comments: true
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-  jackson:
-    property-naming-strategy: SNAKE_CASE
-  kafka:
-    bootstrap-servers: ${KAFKA_SERVER_URL}
-    consumer: # TODO kafka consumer, producer에 대한 설정값 수정은 여기에서
-      group-id: ${spring.application.name}-group
-      auto-offset-reset: earliest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: '*'
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: http://localhost:19000/eureka/
-
-
-management:
-  zipkin:
-    tracing:
-      endpoint: "http://localhost:9411/api/v2/spans"
-  tracing:
-    sampling:
-      probability: 1.0
-
-#모든 엔드포인트 노출 설정
-  endpoints:
-    web:
-      exposure:
-        include: "*"
-#헬스 체크 엔드포인트 상세 정보 표시 설정
-    health:
-      show-details: always
-
-  #프로메테우스 사용활성화
-  metrics:
-    export:
-      prometheus:
-        enabled: true
-
+#server:
+#  port: 19030
+#
+#spring:
+#  application:
+#    name: queue-service
+#  config:
+#    import: classpath:config-repo/application-key.yml
+#  datasource:
+#    driver-class-name: org.postgresql.Driver
+#    url: ${DB_URL}/queue_db
+#    username: ${DB_USERNAME}
+#    password: ${DB_PASSWORD}
+#  data:
+#    redis:
+#      host: ${QUEUE_REDIS_HOSTNAME}
+#      port: ${QUEUE_REDIS_PORT}
+##      username: default
+##      password: password
+#  jpa:
+#    hibernate:
+#      ddl-auto: update
+#    show-sql: true
+#    properties:
+#      format-sql: true
+#      use_sql_comments: true
+#      hibernate:
+#        dialect: org.hibernate.dialect.PostgreSQLDialect
+#  jackson:
+#    property-naming-strategy: SNAKE_CASE
+#  kafka:
+#    bootstrap-servers: ${KAFKA_SERVER_URL}
+#    consumer: # TODO kafka consumer, producer에 대한 설정값 수정은 여기에서
+#      group-id: ${spring.application.name}-group
+#      auto-offset-reset: earliest
+#      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+#      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+#      properties:
+#        spring.json.trusted.packages: '*'
+#    producer:
+#      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+#      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+#
+#eureka:
+#  client:
+#    serviceUrl:
+#      defaultZone: http://localhost:19000/eureka/
+#
+#
+#management:
+#  zipkin:
+#    tracing:
+#      endpoint: "http://localhost:9411/api/v2/spans"
+#  tracing:
+#    sampling:
+#      probability: 1.0
+#
+##모든 엔드포인트 노출 설정
+#  endpoints:
+#    web:
+#      exposure:
+#        include: "*"
+##헬스 체크 엔드포인트 상세 정보 표시 설정
+#    health:
+#      show-details: always
+#
+#  #프로메테우스 사용활성화
+#  metrics:
+#    export:
+#      prometheus:
+#        enabled: true
+#

--- a/config/src/main/resources/config-repo/reservation-service.yml
+++ b/config/src/main/resources/config-repo/reservation-service.yml
@@ -1,64 +1,64 @@
-server:
-  port: 19040
-
-spring:
-  application:
-    name: reservation-service
-  config:
-    import: classpath:config-repo/application-key.yml
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: ${DB_URL}/reservation_db
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      format-sql: true
-      use_sql_comments: true
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-  jackson:
-    property-naming-strategy: SNAKE_CASE
-  kafka:
-    bootstrap-servers: ${KAFKA_SERVER_URL}
-    consumer: # TODO kafka consumer, producer에 대한 설정값 수정은 여기에서
-      group-id: ${spring.application.name}-group
-      auto-offset-reset: earliest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: '*'
-    producer:
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: http://localhost:19000/eureka/
-
-management:
-  zipkin:
-    tracing:
-      endpoint: "http://localhost:9411/api/v2/spans"
-  tracing:
-    sampling:
-      probability: 1.0
-
-  #모든 엔드포인트 노출 설정
-  endpoints:
-    web:
-      exposure:
-        include: "*"
-    #헬스 체크 엔드포인트 상세 정보 표시 설정
-    health:
-      show-details: always
-
-  #프로메테우스 사용활성화
-  metrics:
-    export:
-      prometheus:
-        enabled: true
+#server:
+#  port: 19040
+#
+#spring:
+#  application:
+#    name: reservation-service
+#  config:
+#    import: classpath:config-repo/application-key.yml
+#  datasource:
+#    driver-class-name: org.postgresql.Driver
+#    url: ${DB_URL}/reservation_db
+#    username: ${DB_USERNAME}
+#    password: ${DB_PASSWORD}
+#  jpa:
+#    hibernate:
+#      ddl-auto: update
+#    show-sql: true
+#    properties:
+#      format-sql: true
+#      use_sql_comments: true
+#      hibernate:
+#        dialect: org.hibernate.dialect.PostgreSQLDialect
+#  jackson:
+#    property-naming-strategy: SNAKE_CASE
+#  kafka:
+#    bootstrap-servers: ${KAFKA_SERVER_URL}
+#    consumer: # TODO kafka consumer, producer에 대한 설정값 수정은 여기에서
+#      group-id: ${spring.application.name}-group
+#      auto-offset-reset: earliest
+#      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+#      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+#      properties:
+#        spring.json.trusted.packages: '*'
+#    producer:
+#      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+#      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+#
+#eureka:
+#  client:
+#    serviceUrl:
+#      defaultZone: http://localhost:19000/eureka/
+#
+#management:
+#  zipkin:
+#    tracing:
+#      endpoint: "http://localhost:9411/api/v2/spans"
+#  tracing:
+#    sampling:
+#      probability: 1.0
+#
+#  #모든 엔드포인트 노출 설정
+#  endpoints:
+#    web:
+#      exposure:
+#        include: "*"
+#    #헬스 체크 엔드포인트 상세 정보 표시 설정
+#    health:
+#      show-details: always
+#
+#  #프로메테우스 사용활성화
+#  metrics:
+#    export:
+#      prometheus:
+#        enabled: true

--- a/config/src/main/resources/config-repo/restaurant-service.yml
+++ b/config/src/main/resources/config-repo/restaurant-service.yml
@@ -1,59 +1,59 @@
-server:
-  port: 19020
-
-spring:
-  application:
-    name: restaurant-service
-  datasource:
-    url: jdbc:postgresql://localhost:5432/restaurant_db
-    username: postgres
-    password: password
-    driver-class-name: org.postgresql.Driver
-  data:
-    redis:
-      host: localhost
-      port: 6379
-      username: default
-      password: password
-  jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      format-sql: true
-      use_sql_comments: true
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-  jackson:
-    property-naming-strategy: SNAKE_CASE
-
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: http://localhost:19000/eureka/
-
-
-
-management:
-  zipkin:
-    tracing:
-      endpoint: "http://localhost:9411/api/v2/spans"
-  tracing:
-    sampling:
-      probability: 1.0
-
-  #모든 엔드포인트 노출 설정
-  endpoints:
-    web:
-      exposure:
-        include: "*"
-    #헬스 체크 엔드포인트 상세 정보 표시 설정
-    health:
-      show-details: always
-
-  #프로메테우스 사용활성화
-  metrics:
-    export:
-      prometheus:
-        enabled: true
+#server:
+#  port: 19020
+#
+#spring:
+#  application:
+#    name: restaurant-service
+#  datasource:
+#    url: jdbc:postgresql://localhost:5432/restaurant_db
+#    username: postgres
+#    password: password
+#    driver-class-name: org.postgresql.Driver
+#  data:
+#    redis:
+#      host: localhost
+#      port: 6379
+#      username: default
+#      password: password
+#  jpa:
+#    database-platform: org.hibernate.dialect.PostgreSQLDialect
+#    hibernate:
+#      ddl-auto: update
+#    show-sql: true
+#    properties:
+#      format-sql: true
+#      use_sql_comments: true
+#      hibernate:
+#        dialect: org.hibernate.dialect.PostgreSQLDialect
+#  jackson:
+#    property-naming-strategy: SNAKE_CASE
+#
+#eureka:
+#  client:
+#    serviceUrl:
+#      defaultZone: http://localhost:19000/eureka/
+#
+#
+#
+#management:
+#  zipkin:
+#    tracing:
+#      endpoint: "http://localhost:9411/api/v2/spans"
+#  tracing:
+#    sampling:
+#      probability: 1.0
+#
+#  #모든 엔드포인트 노출 설정
+#  endpoints:
+#    web:
+#      exposure:
+#        include: "*"
+#    #헬스 체크 엔드포인트 상세 정보 표시 설정
+#    health:
+#      show-details: always
+#
+#  #프로메테우스 사용활성화
+#  metrics:
+#    export:
+#      prometheus:
+#        enabled: true

--- a/notification/src/main/resources/application-dev.yml
+++ b/notification/src/main/resources/application-dev.yml
@@ -5,6 +5,8 @@ spring:
     import: "configserver:"
   cloud:
     config:
+      uri: http://localhost:19002 # Config Server 주소
+      label: dev # Git 브랜치
       discovery:
         service-id: config-service
         enabled: true

--- a/notification/src/main/resources/application.yml
+++ b/notification/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
+  application:
+    name: notification-service
   profiles:
-    active: dev
+    default: dev

--- a/payment/src/main/resources/application-dev.yml
+++ b/payment/src/main/resources/application-dev.yml
@@ -5,17 +5,14 @@ spring:
     import: "configserver:"
   cloud:
     config:
+      uri: http://localhost:19002 # Config Server 주소
+      label: dev # Git 브랜치
       discovery:
         service-id: config-service
         enabled: true
+
 
 eureka:
   client:
     serviceUrl:
       defaultZone: http://localhost:19000/eureka/
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: refresh

--- a/queue/src/main/resources/application-dev.yml
+++ b/queue/src/main/resources/application-dev.yml
@@ -5,17 +5,14 @@ spring:
     import: "configserver:"
   cloud:
     config:
+      uri: http://localhost:19002 # Config Server 주소
+      label: dev # Git 브랜치
       discovery:
         service-id: config-service
         enabled: true
+
 
 eureka:
   client:
     serviceUrl:
       defaultZone: http://localhost:19000/eureka/
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: refresh

--- a/queue/src/main/resources/application.yml
+++ b/queue/src/main/resources/application.yml
@@ -1,3 +1,5 @@
 spring:
+  application:
+    name: queue-service
   profiles:
     active: dev

--- a/reservation/src/main/resources/application-dev.yml
+++ b/reservation/src/main/resources/application-dev.yml
@@ -5,17 +5,14 @@ spring:
     import: "configserver:"
   cloud:
     config:
+      uri: http://localhost:19002 # Config Server 주소
+      label: dev # Git 브랜치
       discovery:
         service-id: config-service
         enabled: true
+
 
 eureka:
   client:
     serviceUrl:
       defaultZone: http://localhost:19000/eureka/
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: refresh


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/config-used-on-entire-server -> dev
### 이슈
- #195 
### 
- private git repo인 config-repo의 dev 브런치에 있는 .yml파일을 사용하도록 합니다.
- 명시적인 기능 변화는 없습니다.

![image](https://github.com/user-attachments/assets/51dfe050-820f-4ac4-a1bb-1611bd7d6ced)
private git에 접근하려면 private-key를 사용하도록 변경되었습니다.
(git) private-key 대신username과 password를 사용하셔도 됩니다.
![image](https://github.com/user-attachments/assets/59bc96fa-9a3d-4577-a9d2-0e6ba53ff15d)

환경을 변경하려면
각 서비스에서 .yml 속성값 중 cloud-config-label을 변경하시면 됩니다(현재 기본적으로 모두 dev를 바라보게 해놨습니다.)

환경 추가 역시 repository의 브런치를 추가하여 사용하면 됩니다.
profile(-dev, -prod.yml)등의 사용이 label(브런치)보다 후순위이기 때문에, 이렇게 변경하였습니다.

prod의 경우 영향이 없도록 하기위해 설정을 변경하지 않았습니다.
### To Reviewers
- 리뷰받고 싶은 부분에 대해 작성